### PR TITLE
[Issue #1]: New commands + phrases (en/ro/es)

### DIFF
--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -9,6 +9,66 @@
 	"ro": "dezactivat",
 	"es": "desactivado"
 	},
+	"minutes": {
+		"en": "%.2f minute(s)",
+		"ro": "%.2f minut(e)",
+		"es": "%.2f minuto(s)"
+	},
+	"hours": {
+		"en": "%.2f hour(s)",
+		"ro": "%.2f ore",
+		"es": "%.2f hora(s)"
+	},
+	"days": {
+		"en": "%.2f day(s)",
+		"ro": "%.2f zi(le)",
+		"es": "%.2f día(s)"
+	},
+	"forever": {
+		"en": "Forever",
+		"ro": "Pentru totdeauna",
+		"es": "Para siempre"
+	},
+	"never": {
+		"en": "Never",
+		"ro": "Niciodată",
+		"es": "Nunca"
+	},
+	"invalid_time": {
+		"en": "%s Invalid time. (%d-%d)",
+		"ro": "%s Timp invalid. (%d-%d)",
+		"es": "%s Tiempo inválido. (%d-%d)"
+	},
+	"invalid_player": {
+		"en": "%s Player couldn't be found.\n",
+		"ro": "%s Nu am putut găsi jucătorul.\n",
+		"es": "%s No se pudo encontrar al jugador.\n"
+	},
+	"invalid_immunity": {
+		"en": "%s Invalid immunity.\n",
+		"ro": "%s Imunitate invalidă.\n",
+		"es": "%s Inmunidad inválida.\n"
+	},
+	"invalid_flags": {
+		"en": "%s Invalid flags.\n",
+		"ro": "%s Flag-uri invalide.\n",
+		"es": "%s Flags inválidas.\n"
+	},
+	"is_not_an_admin": {
+		"en": "%s '%s' is not an admin.\n",
+		"ro": "%s '%s' nu este un admin.\n",
+		"es": "%s '%s' no es un administrador.\n"
+	},
+	"invalid_map": {
+		"en": "%s Map '%s' is invalid. Please choose another one.",
+		"ro": "%s Harta '%s' este invalidă. Te rugăm să alegi o altă hartă.",
+		"es": "%s Mapa '%s' es inválido. Por favor elige otro."
+	},
+	"no_access": {
+		"en": "%s You don't have access to use this command.\n",
+		"ro": "%s Nu ai acces să folosești această comandă.\n",
+		"es": "%s No tienes acceso para usar este comando.\n"
+	},
 	"addadmin.message": {
 		"en": "%s %s added '%s' as admin. (Flags: %s, Immunity: %d)\n",
 		"ro": "%s %s l-a adaugat pe '%s' ca și admin. (Flags: %s, Imunitate: %d)\n",
@@ -30,9 +90,9 @@
 		"es": "%s %s prohibió %s por %s. Razón: %s\n"
 	},
 	"ban.syntax": {
-		"en": "%s Syntax: %sban <player> <days / 0 - permanent> <reason>\n",
-		"ro": "%s Sintaxă: %sban <player> <zile / 0 - permanent> <motiv>\n",
-		"es": "%s Sintaxis: %sban <jugador> <días / 0 - permanente> <razón>\n"
+		"en": "%s Syntax: %sban <player> <minutes / 0 - permanent> <reason>\n",
+		"ro": "%s Sintaxă: %sban <player> <minute / 0 - permanent> <motiv>\n",
+		"es": "%s Sintaxis: %sban <jugador> <minutos / 0 - permanente> <razón>\n"
 	},
 	"cannot_use_command": {
 		"en": "%s You don't have access to use this command on that player.\n",
@@ -69,16 +129,6 @@
 		"ro": "%s Sintaxă: %scsay <mesaj>\n",
 		"es": "%s Sintaxis: %scsay <mensaje>\n"
 	},
-	"days": {
-		"en": "%.2f day(s)",
-		"ro": "%.2f zi(le)",
-		"es": "%.2f día(s)"
-	},
-	"forever": {
-		"en": "Forever",
-		"ro": "Pentru totdeauna",
-		"es": "Para siempre"
-	},
 	"gag.message": {
 		"en": "%s %s gagged %s for %s. Reason: %s\n",
 		"ro": "%s %s i-a dat gag lui %s pentru %s. Motiv: %s\n",
@@ -99,41 +149,6 @@
 		"ro": "%s Ai primit gag. Expiră în: %s. Motiv: %s",
 		"es": "%s Estás amordazado. Expira en: %s. Razón: %s"
 	},
-	"hours": {
-		"en": "%.2f hour(s)",
-		"ro": "%.2f ore",
-		"es": "%.2f hora(s)"
-	},
-	"invalid_flags": {
-		"en": "%s Invalid flags.\n",
-		"ro": "%s Flag-uri invalide.\n",
-		"es": "%s Flags inválidas.\n"
-	},
-	"invalid_immunity": {
-		"en": "%s Invalid immunity.\n",
-		"ro": "%s Imunitate invalidă.\n",
-		"es": "%s Inmunidad inválida.\n"
-	},
-	"invalid_map": {
-		"en": "%s Map '%s' is invalid. Please choose another one.",
-		"ro": "%s Harta '%s' este invalidă. Te rugăm să alegi o altă hartă.",
-		"es": "%s Mapa '%s' es inválido. Por favor elige otro."
-	},
-	"invalid_player": {
-		"en": "%s Player couldn't be found.\n",
-		"ro": "%s Nu am putut găsi jucătorul.\n",
-		"es": "%s No se pudo encontrar al jugador.\n"
-	},
-	"invalid_time": {
-		"en": "%s Invalid time. (%d-%d)",
-		"ro": "%s Timp invalid. (%d-%d)",
-		"es": "%s Tiempo inválido. (%d-%d)"
-	},
-	"is_not_an_admin": {
-		"en": "%s '%s' is not an admin.\n",
-		"ro": "%s '%s' nu este un admin.\n",
-		"es": "%s '%s' no es un administrador.\n"
-	},
 	"kick.message": {
 		"en": "%s %s kicked %s from server. Reason: %s\n",
 		"ro": "%s %s i-a dat kick lui %s de pe server. Motiv: %s\n",
@@ -143,11 +158,6 @@
 		"en": "%s Syntax: %skick <player> <reason>\n",
 		"ro": "%s Sintaxă: %skick <player> <motiv>\n",
 		"es": "%s Sintaxis: %skick <jugador> <razón>\n"
-	},
-	"minutes": {
-		"en": "%.2f minute(s)",
-		"ro": "%.2f minut(e)",
-		"es": "%.2f minuto(s)"
 	},
 	"mute.message": {
 		"en": "%s %s muted %s for %s. Reason: %s\n",
@@ -168,16 +178,6 @@
 		"en": "%s You are muted. Expires in: %s. Reason: %s",
 		"ro": "%s Ai primit mute. Expiră în: %s. Motiv: %s",
 		"es": "%s Estás silenciado. Expira en: %s. Razón: %s"
-	},
-	"never": {
-		"en": "Never",
-		"ro": "Niciodată",
-		"es": "Nunca"
-	},
-	"no_access": {
-		"en": "%s You don't have access to use this command.\n",
-		"ro": "%s Nu ai acces să folosești această comandă.\n",
-		"es": "%s No tienes acceso para usar este comando.\n"
 	},
 	"player_already_gagged": {
 		"en": "%s %s is already gagged.\n",
@@ -359,49 +359,59 @@
 		"es": "%s Sintaxis: %srg <tiempo>\n"
 	},
 	"rg.cancel": {
-		"en": "%s Round restart has been cancelled.\n",
-		"ro": "%s Restartul rundei a fost anulat.\n",
-		"es": "%s El reinicio de la ronda ha sido cancelado.\n"
+		"en": "%s Restart game has been cancelled.\n",
+		"ro": "%s Restartul jocului a fost anulat.\n",
+		"es": "%s El reinicio del juego ha sido cancelado.\n"
 	},
 	"rg.no_restart": {
-		"en": "%s There is no round restart in progress.\n",
-		"ro": "%s Nu există niciun restart de rundă în desfășurare.\n",
-		"es": "%s No hay reinicio de ronda en progreso.\n"
+		"en": "%s There is no game restart in progress.\n",
+		"ro": "%s Nu există niciun restart de joc în desfășurare.\n",
+		"es": "%s No hay reinicio de juego en progreso.\n"
 	},
 	"rg.message": {
-		"en": "%s %s has initiated a round restart. It will happen in %d second(s).\n",
-		"ro": "%s %s a inițiat un restart de rundă. Acesta va avea loc în %d secundă(e).\n",
-		"es": "%s %s ha iniciado un reinicio de ronda. Ocurrirá en %d segundo(s).\n"
+		"en": "%s %s has initiated a restart game. It will happen in %d second(s).\n",
+		"ro": "%s %s a inițiat un restart de joc. Acesta va avea loc în %d secundă(e).\n",
+		"es": "%s %s ha iniciado un reinicio de juego. Ocurrirá en %d segundo(s).\n"
 	},
 	"hp.syntax": {
-		"en": "%s Syntax: %shp <player> <health> [armor]\n",
-		"ro": "%s Sintaxă: %shp <player> <sănătate> [armură]\n",
-		"es": "%s Sintaxis: %shp <jugador> <salud> [armadura]\n"
+		"en": "%s Syntax: %shp <player> <health> [armor] [helmet]\n",
+		"ro": "%s Sintaxă: %shp <player> <sănătate> [armură] [coif]\n",
+		"es": "%s Sintaxis: %shp <jugador> <salud> [armadura] [casco]\n"
 	},
-	"hp.message1": {
+	"hp.message": {
 		"en": "%s %s has set %s's health to %d.\n",
 		"ro": "%s %s i-a setat sănătatea lui %s la %d.\n",
 		"es": "%s %s ha establecido la salud de %s a %d.\n"
 	},
-	"hp.message2": {
+	"hp.message_with_armor": {
 		"en": "%s %s has set %s's stats to [HP: %d | ARMOR: %d].\n",
 		"ro": "%s %s i-a setat statisticile lui %s la [HP: %d | ARMOR: %d].\n",
 		"es": "%s %s ha establecido las estadísticas de %s a [HP: %d | ARMOR: %d].\n"
 	},
-	"hp.message3": {
-		"en": "%s %s has set %s's stats to [HP: %d | ARMOR: %d | KEVLAR: %d].\n",
-		"ro": "%s %s i-a setat statisticile lui %s la [HP: %d | ARMOR: %d | KEVLAR: %d].\n",
-		"es": "%s %s ha establecido las estadísticas de %s a [HP: %d | ARMOR: %d | KEVLAR: %d].\n"
+	"hp.message_with_armor_and_helmet": {
+		"en": "%s %s has set %s's stats to [HP: %d | ARMOR: %d | HELMET: %d].\n",
+		"ro": "%s %s i-a setat statisticile lui %s la [HP: %d | ARMOR: %d | HELMET: %d].\n",
+		"es": "%s %s ha establecido las estadísticas de %s a [HP: %d | ARMOR: %d | HELMET: %d].\n"
 	},
 	"hp.invalid_health": {
 		"en": "%s Invalid health value. (%d-%d)\n",
 		"ro": "%s Valoare de sănătate invalidă. (%d-%d)\n",
 		"es": "%s Valor de salud inválido. (%d-%d)\n"
 	},
+	"hp.invalid_armor": {
+		"en": "%s Invalid armor value. (%d-%d)\n",
+		"ro": "%s Valoare de armură invalidă. (%d-%d)\n",
+		"es": "%s Valor de armadura inválido. (%d-%d)\n"
+	},
+	"hp.invalid_helmet": {
+		"en": "%s Invalid helmet value. (%d-%d)\n",
+		"ro": "%s Valoare de coif invalidă. (%d-%d)\n",
+		"es": "%s Valor de casco inválido. (%d-%d)\n"
+	},
 	"team.syntax": {
-		"en": "%s Syntax: %steam <player> <team>\n",
-		"ro": "%s Sintaxă: %steam <player> <echipă>\n",
-		"es": "%s Sintaxis: %steam <jugador> <equipo>\n"
+		"en": "%s Syntax: %steam <player> <CT/T/SPEC>\n",
+		"ro": "%s Sintaxă: %steam <player> <CT/T/SPEC>\n",
+		"es": "%s Sintaxis: %steam <jugador> <CT/T/SPEC>\n"
 	},
 	"team.invalid_team": {
 		"en": "%s Invalid team.\n",
@@ -414,9 +424,9 @@
 		"es": "%s %s ha movido a %s al equipo %s.\n"
 	},
 	"swap.syntax": {
-		"en": "%s Syntax: %sswap <player1> <player2>\n",
-		"ro": "%s Sintaxă: %sswap <player1> <player2>\n",
-		"es": "%s Sintaxis: %sswap <jugador1> <jugador2>\n"
+		"en": "%s Syntax: %sswap <player>\n",
+		"ro": "%s Sintaxă: %sswap <player>\n",
+		"es": "%s Sintaxis: %sswap <jugador>\n"
 	},
 	"swap.message": {
 		"en": "%s %s has team-swapped %s.\n",
@@ -587,5 +597,85 @@
 		"en": "%s %s has set %s's noclip to '%s'.\n",
 		"ro": "%s %s i-a setat lui %s noclip-ul la '%s'.\n",
 		"es": "%s %s ha establecido el noclip de %s a '%s'.\n"
+	},
+	"freeze.syntax": {
+		"en": "%s Syntax: %sfreeze <player>\n",
+		"ro": "%s Sintaxă: %sfreeze <player>\n",
+		"es": "%s Sintaxis: %sfreeze <jugador>\n"
+	},
+	"player_already_freezed": {
+		"en": "%s %s is already freezed.\n",
+		"ro": "%s %s este deja înghețat.\n",
+		"es": "%s %s ya está congelado.\n"
+	},
+	"freeze.message": {
+		"en": "%s %s has freezed %s.\n",
+		"ro": "%s %s a înghețat pe %s.\n",
+		"es": "%s %s ha congelado a %s.\n"
+	},
+	"unfreeze.syntax": {
+		"en": "%s Syntax: %sunfreeze <player>\n",
+		"ro": "%s Sintaxă: %sunfreeze <player>\n",
+		"es": "%s Sintaxis: %sunfreeze <jugador>\n"
+	},
+	"player_not_freezed": {
+		"en": "%s %s is not freezed.\n",
+		"ro": "%s %s nu este înghețat.\n",
+		"es": "%s %s no está congelado.\n"
+	},
+	"unfreeze.message": {
+		"en": "%s %s has unfreezed %s.\n",
+		"ro": "%s %s a dezghețat pe %s.\n",
+		"es": "%s %s ha descongelado a %s.\n"
+	},
+	"bury.syntax": {
+		"en": "%s Syntax: %sbury <player>\n",
+		"ro": "%s Sintaxă: %sbury <player>\n",
+		"es": "%s Sintaxis: %sbury <jugador>\n"
+	},
+	"bury.message": {
+		"en": "%s %s has buried %s.\n",
+		"ro": "%s %s a îngropat pe %s.\n",
+		"es": "%s %s ha enterrado a %s.\n"
+	},
+	"unbury.syntax": {
+		"en": "%s Syntax: %sunbury <player>\n",
+		"ro": "%s Sintaxă: %sunbury <player>\n",
+		"es": "%s Sintaxis: %sunbury <jugador>\n"
+	},
+	"unbury.message": {
+		"en": "%s %s has unburied %s.\n",
+		"ro": "%s %s a dezgropat pe %s.\n",
+		"es": "%s %s ha desenterrado a %s.\n"
+	},
+	"uslap.syntax": {
+		"en": "%s Syntax: %suslap <player> <times> [damage]\n",
+		"ro": "%s Sintaxă: %suslap <player> <ori> [daune]\n",
+		"es": "%s Sintaxis: %suslap <jugador> <veces> [daño]\n"
+	},
+	"uslap.invalid_times": {
+		"en": "%s Invalid slap times. (%d-%d)\n",
+		"ro": "%s Număr de slap-uri invalid. (%d-%d)\n",
+		"es": "%s Número de bofetadas inválido. (%d-%d)\n"
+	},
+	"uslap.invalid_damage": {
+		"en": "%s Invalid slap damage.\n",
+		"ro": "%s Daune de slap invalide.\n",
+		"es": "%s Daño de bofetada inválido.\n"
+	},
+	"uslap.message": {
+		"en": "%s %s has slapped %s %d times with %d damage.\n",
+		"ro": "%s %s a dat slap lui %s de %d ori cu %d daune.\n",
+		"es": "%s %s ha abofeteado a %s %d veces con %d de daño.\n"
+	},
+	"rename.syntax": {
+		"en": "%s Syntax: %srename <player> <name>\n",
+		"ro": "%s Sintaxă: %srename <player> <nume>\n",
+		"es": "%s Sintaxis: %srename <jugador> <nombre>\n"
+	},
+	"rename.message": {
+		"en": "%s %s has renamed %s to %s.\n",
+		"ro": "%s %s a redenumit pe %s la %s.\n",
+		"es": "%s %s ha renombrado a %s a %s.\n"
 	}
 }

--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -474,9 +474,9 @@
 		"es": "%s Sintaxis: %sxyz <jugador>\n"
 	},
 	"xyz.message.server":{
-		"en": "%s %s's coordinates: %s\n",
-		"ro": "%s Coordonatele lui %s: %s\n",
-		"es": "%s Coordenadas de %s: %s\n"
+		"en": "%s %s's coordinates: [%s | %s | %s]\n",
+		"ro": "%s Coordonatele lui %s: [%s | %s | %s]\n",
+		"es": "%s Coordenadas de %s: [%s | %s | %s]\n"
 	},
 	"xyz.syntax.client": {
 		"en": "%s Syntax: %sxyz\n",
@@ -484,8 +484,8 @@
 		"es": "%s Sintaxis: %sxyz\n"
 	},
 	"xyz.message.client":{
-		"en": "%s Your coordinates: %s\n",
-		"ro": "%s Coordonatele tale: %s\n",
-		"es": "%s Tus coordenadas: %s\n"
+		"en": "%s Your coordinates: [%s | %s | %s]\n",
+		"ro": "%s Coordonatele tale: [%s | %s | %s]\n",
+		"es": "%s Tus coordenadas: [%s | %s | %s]\n"
 	}
 }

--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -317,5 +317,175 @@
 		"en": "%s Syntax: %sunsilence <player>\n",
 		"ro": "%s Sintaxă: %sunsilence <player>\n",
 		"es": "%s Sintaxis: %sunsilence <jugador>\n"
+	},
+	"rr.syntax": {
+		"en": "%s Syntax: %srr <time>\n",
+		"ro": "%s Sintaxă: %srr <timp>\n",
+		"es": "%s Sintaxis: %srr <tiempo>\n"
+	},
+	"rr.cancel": {
+		"en": "%s Round restart has been cancelled.\n",
+		"ro": "%s Restartul rundei a fost anulat.\n",
+		"es": "%s El reinicio de la ronda ha sido cancelado.\n"
+	},
+	"rr.no_restart": {
+		"en": "%s There is no round restart in progress.\n",
+		"ro": "%s Nu există niciun restart de rundă în desfășurare.\n",
+		"es": "%s No hay reinicio de ronda en progreso.\n"
+	},
+	"rr.message": {
+		"en": "%s %s has initiated a round restart. It will happen in %d second(s).\n",
+		"ro": "%s %s a inițiat un restart de rundă. Acesta va avea loc în %d secundă(e).\n",
+		"es": "%s %s ha iniciado un reinicio de ronda. Ocurrirá en %d segundo(s).\n"
+	},
+	"rg.syntax": {
+		"en": "%s Syntax: %srg <time>\n",
+		"ro": "%s Sintaxă: %srg <timp>\n",
+		"es": "%s Sintaxis: %srg <tiempo>\n"
+	},
+	"rg.cancel": {
+		"en": "%s Round restart has been cancelled.\n",
+		"ro": "%s Restartul rundei a fost anulat.\n",
+		"es": "%s El reinicio de la ronda ha sido cancelado.\n"
+	},
+	"rg.no_restart": {
+		"en": "%s There is no round restart in progress.\n",
+		"ro": "%s Nu există niciun restart de rundă în desfășurare.\n",
+		"es": "%s No hay reinicio de ronda en progreso.\n"
+	},
+	"rg.message": {
+		"en": "%s %s has initiated a round restart. It will happen in %d second(s).\n",
+		"ro": "%s %s a inițiat un restart de rundă. Acesta va avea loc în %d secundă(e).\n",
+		"es": "%s %s ha iniciado un reinicio de ronda. Ocurrirá en %d segundo(s).\n"
+	},
+	"hp.syntax": {
+		"en": "%s Syntax: %shp <player> <health>\n",
+		"ro": "%s Sintaxă: %shp <player> <sănătate>\n",
+		"es": "%s Sintaxis: %shp <jugador> <salud>\n"
+	},
+	"hp.message": {
+		"en": "%s %s has set %s's health to %d.\n",
+		"ro": "%s %s i-a setat sănătatea lui %s la %d.\n",
+		"es": "%s %s ha establecido la salud de %s a %d.\n"
+	},
+	"hp.invalid_health": {
+		"en": "%s Invalid health value. (%d-%d)\n",
+		"ro": "%s Valoare de sănătate invalidă. (%d-%d)\n",
+		"es": "%s Valor de salud inválido. (%d-%d)\n"
+	},
+	"team.syntax": {
+		"en": "%s Syntax: %steam <player> <team>\n",
+		"ro": "%s Sintaxă: %steam <player> <echipă>\n",
+		"es": "%s Sintaxis: %steam <jugador> <equipo>\n"
+	},
+	"team.invalid_team": {
+		"en": "%s Invalid team.\n",
+		"ro": "%s Echipă invalidă.\n",
+		"es": "%s Equipo inválido.\n"
+	},
+	"team.message": {
+		"en": "%s %s has moved %s to team %s.\n",
+		"ro": "%s %s l-a mutat pe %s la echipa %s.\n",
+		"es": "%s %s ha movido a %s al equipo %s.\n"
+	},
+	"swap.syntax": {
+		"en": "%s Syntax: %sswap <player1> <player2>\n",
+		"ro": "%s Sintaxă: %sswap <player1> <player2>\n",
+		"es": "%s Sintaxis: %sswap <jugador1> <jugador2>\n"
+	},
+	"swap.message": {
+		"en": "%s %s has team-swapped %s.\n",
+		"ro": "%s %s a schimbat echipa lui %s.\n",
+		"es": "%s %s ha cambiado de equipo a %s.\n"
+	},
+	"respawn.syntax": {
+		"en": "%s Syntax: %srespawn <player>\n",
+		"ro": "%s Sintaxă: %srespawn <player>\n",
+		"es": "%s Sintaxis: %srespawn <jugador>\n"
+	},
+	"respawn.message": {
+		"en": "%s %s has respawned %s.\n",
+		"ro": "%s %s a respawnat pe %s.\n",
+		"es": "%s %s ha reaparecido a %s.\n"
+	},
+	"cc.syntax": {
+		"en": "%s Syntax: %scc\n",
+		"ro": "%s Sintaxă: %scc\n",
+		"es": "%s Sintaxis: %scc\n"
+	},
+	"cc.message": {
+		"en": "%s %s has cleared chat.\n",
+		"ro": "%s %s a șters chat-ul.\n",
+		"es": "%s %s ha limpiado el chat.\n"
+	},
+	"give.syntax": {
+		"en": "%s Syntax: %sgive <player> <weapon>\n",
+		"ro": "%s Sintaxă: %sgive <player> <armă>\n",
+		"es": "%s Sintaxis: %sgive <jugador> <arma>\n"
+	},
+	"give.message": {
+		"en": "%s %s has given %s a %s.\n",
+		"ro": "%s %s a dat lui %s un %s.\n",
+		"es": "%s %s ha dado a %s un(a) %s.\n"
+	},
+	"give.invalid_weapon": {
+		"en": "%s Invalid weapon.\n",
+		"ro": "%s Arma invalidă.\n",
+		"es": "%s Arma inválida.\n"
+	},
+	"giveitem.syntax": {
+		"en": "%s Syntax: %sgiveitem <player> <item>\n",
+		"ro": "%s Sintaxă: %sgiveitem <player> <item>\n",
+		"es": "%s Sintaxis: %sgiveitem <jugador> <item>\n"
+	},
+	"giveitem.message": {
+		"en": "%s %s has given %s a %s.\n",
+		"ro": "%s %s a dat lui %s un %s.\n",
+		"es": "%s %s ha dado a %s un(a) %s.\n"
+	},
+	"giveitem.invalid_item": {
+		"en": "%s Invalid item.\n",
+		"ro": "%s Item invalid.\n",
+		"es": "%s Ítem inválido.\n"
+	},
+	"melee.syntax": {
+		"en": "%s Syntax: %smelee <player>\n",
+		"ro": "%s Sintaxă: %smelee <player>\n",
+		"es": "%s Sintaxis: %smelee <jugador>\n"
+	},
+	"melee.message": {
+		"en": "%s %s left %s only with a knife.\n",
+		"ro": "%s %s l-a lăsat pe %s doar cu cuțitul.\n",
+		"es": "%s %s dejó a %s solamente con un cuchillo.\n"
+	},
+	"disarm.syntax": {
+		"en": "%s Syntax: %sdisarm <player>\n",
+		"ro": "%s Sintaxă: %sdisarm <player>\n",
+		"es": "%s Sintaxis: %sdisarm <jugador>\n"
+	},
+	"disarm.message": {
+		"en": "%s %s left %s without any weapons.\n",
+		"ro": "%s %s l-a lăsat pe %s fără arme.\n",
+		"es": "%s %s dejó a %s sin armas.\n"
+	},
+	"xyz.syntax.server": {
+		"en": "%s Syntax: %sxyz <player>\n",
+		"ro": "%s Sintaxă: %sxyz <player>\n",
+		"es": "%s Sintaxis: %sxyz <jugador>\n"
+	},
+	"xyz.message.server":{
+		"en": "%s %s's coordinates: %s\n",
+		"ro": "%s Coordonatele lui %s: %s\n",
+		"es": "%s Coordenadas de %s: %s\n"
+	},
+	"xyz.syntax.client": {
+		"en": "%s Syntax: %sxyz\n",
+		"ro": "%s Sintaxă: %sxyz\n",
+		"es": "%s Sintaxis: %sxyz\n"
+	},
+	"xyz.message.client":{
+		"en": "%s Your coordinates: %s\n",
+		"ro": "%s Coordonatele tale: %s\n",
+		"es": "%s Tus coordenadas: %s\n"
 	}
 }

--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -532,5 +532,50 @@
 		"en": "%s %s has set %s's armor to %d.\n",
 		"ro": "%s %s i-a setat armura lui %s la %d.\n",
 		"es": "%s %s ha establecido la armadura de %s a %d.\n"
+	},
+	"1up.syntax": {
+		"en": "%s Syntax: %s1up <player>\n",
+		"ro": "%s Sintaxă: %s1up <player>\n",
+		"es": "%s Sintaxis: %s1up <jugador>\n"
+	},
+	"1up.no_death_position": {
+		"en": "%s %s has no death position saved.\n",
+		"ro": "%s %s nu are o poziție de moarte salvată.\n",
+		"es": "%s %s no tiene una posición de muerte guardada.\n"
+	},
+	"1up.message": {
+		"en": "%s %s has respawned and teleported to his death position.\n",
+		"ro": "%s %s a respawnat și a fost teleportat la poziția sa de moarte.\n",
+		"es": "%s %s ha reaparecido y ha sido teletransportado a su posición de muerte.\n"
+	},
+	"tele.syntax": {
+		"en": "%s Syntax: %stele <player> <player>\n",
+		"ro": "%s Sintaxă: %stele <player> <player>\n",
+		"es": "%s Sintaxis: %stele <jugador> <jugador>\n"
+	},
+	"tele.message": {
+		"en": "%s %s has teleported %s to %s.\n",
+		"ro": "%s %s a teleportat pe %s la %s.\n",
+		"es": "%s %s ha teletransportado a %s a %s.\n"
+	},
+	"bring.syntax": {
+		"en": "%s Syntax: %sbring <player>\n",
+		"ro": "%s Sintaxă: %sbring <player>\n",
+		"es": "%s Sintaxis: %sbring <jugador>\n"
+	},
+	"bring.message": {
+		"en": "%s %s has brought %s to his position.\n",
+		"ro": "%s %s a adus pe %s la poziția sa.\n",
+		"es": "%s %s ha traído a %s a su posición.\n"
+	},
+	"goto.syntax": {
+		"en": "%s Syntax: %sgoto <player>\n",
+		"ro": "%s Sintaxă: %sgoto <player>\n",
+		"es": "%s Sintaxis: %sgoto <jugador>\n"
+	},
+	"goto.message": {
+		"en": "%s %s has teleported to %s.\n",
+		"ro": "%s %s s-a teleportat la %s.\n",
+		"es": "%s %s se ha teletransportado a %s.\n"
 	}
 }

--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -577,5 +577,15 @@
 		"en": "%s %s has teleported to %s.\n",
 		"ro": "%s %s s-a teleportat la %s.\n",
 		"es": "%s %s se ha teletransportado a %s.\n"
+	},
+	"noclip.syntax": {
+		"en": "%s Syntax: %snoclip <player>\n",
+		"ro": "%s Sintaxă: %snoclip <player>\n",
+		"es": "%s Sintaxis: %snoclip <jugador>\n"
+	},
+	"noclip.message": {
+		"en": "%s %s has set %s's noclip to '%s'.\n",
+		"ro": "%s %s i-a setat lui %s noclip-ul la '%s'.\n",
+		"es": "%s %s ha establecido el noclip de %s a '%s'.\n"
 	}
 }

--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -1,4 +1,14 @@
 {
+	"enabled": {
+	"en": "enabled",
+	"ro": "activat",
+	"es": "activado"
+	},
+	"disabled": {
+	"en": "disabled",
+	"ro": "dezactivat",
+	"es": "desactivado"
+	},
 	"addadmin.message": {
 		"en": "%s %s added '%s' as admin. (Flags: %s, Immunity: %d)\n",
 		"ro": "%s %s l-a adaugat pe '%s' ca și admin. (Flags: %s, Imunitate: %d)\n",
@@ -504,9 +514,9 @@
 		"es": "%s Sintaxis: %sgod <jugador>\n"
 	},
 	"god.message": {
-		"en": "%s %s has toggled god mode for %s.\n",
-		"ro": "%s %s a activat/dezactivat modul zeu pentru %s.\n",
-		"es": "%s %s ha activado/desactivado el modo dios para %s.\n"
+		"en": "%s %s has set %s's godmode to '%s'.\n",
+		"ro": "%s %s i-a setat lui %s godmode-ul la '%s'.\n",
+		"es": "%s %s ha establecido el modo dios de %s a '%s'.\n"
 	},
 	"armor.syntax": {
 		"en": "%s Syntax: %sarmor <player> <armor>\n",

--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -278,6 +278,11 @@
 		"ro": "%s %s i-a dat slap lui %s.\n",
 		"es": "%s %s abofeteó a %s.\n"
 	},
+	"slap.message_with_damage": {
+		"en": "%s %s slapped %s with %d damage.\n",
+		"ro": "%s %s i-a dat slap lui %s cu %d de daune.\n",
+		"es": "%s %s abofeteó a %s con %d de daño.\n"
+	},
 	"slap.syntax": {
 		"en": "%s Syntax: %sslap <player>\n",
 		"ro": "%s Sintaxă: %sslap <player>\n",

--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -359,14 +359,24 @@
 		"es": "%s %s ha iniciado un reinicio de ronda. Ocurrirá en %d segundo(s).\n"
 	},
 	"hp.syntax": {
-		"en": "%s Syntax: %shp <player> <health>\n",
-		"ro": "%s Sintaxă: %shp <player> <sănătate>\n",
-		"es": "%s Sintaxis: %shp <jugador> <salud>\n"
+		"en": "%s Syntax: %shp <player> <health> [armor]\n",
+		"ro": "%s Sintaxă: %shp <player> <sănătate> [armură]\n",
+		"es": "%s Sintaxis: %shp <jugador> <salud> [armadura]\n"
 	},
-	"hp.message": {
+	"hp.message1": {
 		"en": "%s %s has set %s's health to %d.\n",
 		"ro": "%s %s i-a setat sănătatea lui %s la %d.\n",
 		"es": "%s %s ha establecido la salud de %s a %d.\n"
+	},
+	"hp.message2": {
+		"en": "%s %s has set %s's stats to [HP: %d | ARMOR: %d].\n",
+		"ro": "%s %s i-a setat statisticile lui %s la [HP: %d | ARMOR: %d].\n",
+		"es": "%s %s ha establecido las estadísticas de %s a [HP: %d | ARMOR: %d].\n"
+	},
+	"hp.message3": {
+		"en": "%s %s has set %s's stats to [HP: %d | ARMOR: %d | KEVLAR: %d].\n",
+		"ro": "%s %s i-a setat statisticile lui %s la [HP: %d | ARMOR: %d | KEVLAR: %d].\n",
+		"es": "%s %s ha establecido las estadísticas de %s a [HP: %d | ARMOR: %d | KEVLAR: %d].\n"
 	},
 	"hp.invalid_health": {
 		"en": "%s Invalid health value. (%d-%d)\n",
@@ -487,5 +497,25 @@
 		"en": "%s Your coordinates: [%s | %s | %s]\n",
 		"ro": "%s Coordonatele tale: [%s | %s | %s]\n",
 		"es": "%s Tus coordenadas: [%s | %s | %s]\n"
+	},
+	"god.syntax": {
+		"en": "%s Syntax: %sgod <player>\n",
+		"ro": "%s Sintaxă: %sgod <player>\n",
+		"es": "%s Sintaxis: %sgod <jugador>\n"
+	},
+	"god.message": {
+		"en": "%s %s has toggled god mode for %s.\n",
+		"ro": "%s %s a activat/dezactivat modul zeu pentru %s.\n",
+		"es": "%s %s ha activado/desactivado el modo dios para %s.\n"
+	},
+	"armor.syntax": {
+		"en": "%s Syntax: %sarmor <player> <armor>\n",
+		"ro": "%s Sintaxă: %sarmor <player> <armură>\n",
+		"es": "%s Sintaxis: %sarmor <jugador> <armadura>\n"
+	},
+	"armor.message": {
+		"en": "%s %s has set %s's armor to %d.\n",
+		"ro": "%s %s i-a setat armura lui %s la %d.\n",
+		"es": "%s %s ha establecido la armadura de %s a %d.\n"
 	}
 }

--- a/plugin_files/translations/translation.admins.json
+++ b/plugin_files/translations/translation.admins.json
@@ -1,179 +1,223 @@
 {
 	"addadmin.message": {
 		"en": "%s %s added '%s' as admin. (Flags: %s, Immunity: %d)\n",
-		"ro": "%s %s l-a adaugat pe '%s' ca și admin. (Flags: %s, Imunitate: %d)\n"
+		"ro": "%s %s l-a adaugat pe '%s' ca și admin. (Flags: %s, Imunitate: %d)\n",
+		"es": "%s %s añadió a '%s' como administrador. (Flags: %s, Inmunidad: %d)\n"
 	},
 	"addadmin.syntax": {
 		"en": "%s Syntax: %saddadmin <steamid64> <flags> <immunity>\n",
-		"ro": "%s Sintaxă: %saddadmin <steamid64> <flags> <immunity>\n"
+		"ro": "%s Sintaxă: %saddadmin <steamid64> <flags> <immunity>\n",
+		"es": "%s Sintaxis: %saddadmin <steamid64> <flags> <inmunidad>\n"
 	},
 	"already_has_admin": {
 		"en": "%s '%s' already has admin.\n",
-		"ro": "%s '%s' deja are admin.\n"
+		"ro": "%s '%s' deja are admin.\n",
+		"es": "%s '%s' ya tiene administrador.\n"
 	},
 	"ban.message": {
 		"en": "%s %s banned %s for %s. Reason: %s\n",
-		"ro": "%s %s i-a dat ban lui %s pentru %s. Motiv: %s\n"
+		"ro": "%s %s i-a dat ban lui %s pentru %s. Motiv: %s\n",
+		"es": "%s %s prohibió %s por %s. Razón: %s\n"
 	},
 	"ban.syntax": {
 		"en": "%s Syntax: %sban <player> <days / 0 - permanent> <reason>\n",
-		"ro": "%s Sintaxă: %sban <player> <zile / 0 - permanent> <motiv>\n"
+		"ro": "%s Sintaxă: %sban <player> <zile / 0 - permanent> <motiv>\n",
+		"es": "%s Sintaxis: %sban <jugador> <días / 0 - permanente> <razón>\n"
 	},
 	"cannot_use_command": {
 		"en": "%s You don't have access to use this command on that player.\n",
-		"ro": "%s Nu ai acces să folosești această comandă pe acest jucător.\n"
+		"ro": "%s Nu ai acces să folosești această comandă pe acest jucător.\n",
+		"es": "%s No tienes acceso para usar este comando en ese jugador.\n"
 	},
 	"changemap.syntax": {
 		"en": "%s Syntax: %smap <map>\n",
-		"ro": "%s Sintaxă: %smap <hartă>\n"
+		"ro": "%s Sintaxă: %smap <hartă>\n",
+		"es": "%s Sintaxis: %smap <mapa>\n"
 	},
 	"changing_map": {
 		"en": "%s Changing map to '%s'...",
-		"ro": "%s Se schimbă harta în '%s'..."
+		"ro": "%s Se schimbă harta în '%s'...",
+		"es": "%s Cambiando mapa a '%s'..."
 	},
 	"chat.admin_chat": {
 		"en": "{green}(Admin Chat) %s{default}: %s\n",
-		"ro": "{green}(Admin Chat) %s{default}: %s\n"
+		"ro": "{green}(Admin Chat) %s{default}: %s\n",
+		"es": "{green}(Chat de Admin) %s{default}: %s\n"
 	},
 	"chat.syntax": {
 		"en": "%s Syntax: %schat <message>\n",
-		"ro": "%s Sintaxă: %schat <mesaj>\n"
+		"ro": "%s Sintaxă: %schat <mesaj>\n",
+		"es": "%s Sintaxis: %schat <mensaje>\n"
 	},
 	"chat.to_admins": {
 		"en": "{green}(To Admins) %s{default}: %s\n",
-		"ro": "{green}(Către Admini) %s{default}: %s\n"
+		"ro": "{green}(Către Admini) %s{default}: %s\n",
+		"es": "{green}(Para Admins) %s{default}: %s\n"
 	},
 	"csay.syntax": {
 		"en": "%s Syntax: %scsay <message>\n",
-		"ro": "%s Sintaxă: %scsay <mesaj>\n"
+		"ro": "%s Sintaxă: %scsay <mesaj>\n",
+		"es": "%s Sintaxis: %scsay <mensaje>\n"
 	},
 	"days": {
 		"en": "%.2f day(s)",
-		"ro": "%.2f zi(le)"
+		"ro": "%.2f zi(le)",
+		"es": "%.2f día(s)"
 	},
 	"forever": {
 		"en": "Forever",
-		"ro": "Pentru totdeauna"
+		"ro": "Pentru totdeauna",
+		"es": "Para siempre"
 	},
 	"gag.message": {
 		"en": "%s %s gagged %s for %s. Reason: %s\n",
-		"ro": "%s %s i-a dat gag lui %s pentru %s. Motiv: %s\n"
+		"ro": "%s %s i-a dat gag lui %s pentru %s. Motiv: %s\n",
+		"es": "%s %s amordazó %s por %s. Razón: %s\n"
 	},
 	"gag.syntax": {
 		"en": "%s Syntax: %sgag <player> <minutes / 0 - permanent> <reason>\n",
-		"ro": "%s Sintaxă: %sgag <player> <minute / 0 - permanent> <motiv>\n"
+		"ro": "%s Sintaxă: %sgag <player> <minute / 0 - permanent> <motiv>\n",
+		"es": "%s Sintaxis: %sgag <jugador> <minutos / 0 - permanente> <razón>\n"
 	},
 	"gag_expired": {
 		"en": "%s Your gag has expired.",
-		"ro": "%s Gag-ul tău a expirat."
+		"ro": "%s Gag-ul tău a expirat.",
+		"es": "%s Tu amordazamiento ha expirado."
 	},
 	"gagged": {
 		"en": "%s You are gagged. Expires in: %s. Reason: %s",
-		"ro": "%s Ai primit gag. Expiră în: %s. Motiv: %s"
+		"ro": "%s Ai primit gag. Expiră în: %s. Motiv: %s",
+		"es": "%s Estás amordazado. Expira en: %s. Razón: %s"
 	},
 	"hours": {
 		"en": "%.2f hour(s)",
-		"ro": "%.2f ore"
+		"ro": "%.2f ore",
+		"es": "%.2f hora(s)"
 	},
 	"invalid_flags": {
 		"en": "%s Invalid flags.\n",
-		"ro": "%s Flag-uri invalide.\n"
+		"ro": "%s Flag-uri invalide.\n",
+		"es": "%s Flags inválidas.\n"
 	},
 	"invalid_immunity": {
 		"en": "%s Invalid immunity.\n",
-		"ro": "%s Imunitate invalidă.\n"
+		"ro": "%s Imunitate invalidă.\n",
+		"es": "%s Inmunidad inválida.\n"
 	},
 	"invalid_map": {
 		"en": "%s Map '%s' is invalid. Please choose another one.",
-		"ro": "%s Harta '%s' este invalidă. Te rugăm să alegi o altă hartă."
+		"ro": "%s Harta '%s' este invalidă. Te rugăm să alegi o altă hartă.",
+		"es": "%s Mapa '%s' es inválido. Por favor elige otro."
 	},
 	"invalid_player": {
 		"en": "%s Player couldn't be found.\n",
-		"ro": "%s Nu am putut găsi jucătorul.\n"
+		"ro": "%s Nu am putut găsi jucătorul.\n",
+		"es": "%s No se pudo encontrar al jugador.\n"
 	},
 	"invalid_time": {
 		"en": "%s Invalid time. (%d-%d)",
-		"ro": "%s Timp invalid. (%d-%d)"
+		"ro": "%s Timp invalid. (%d-%d)",
+		"es": "%s Tiempo inválido. (%d-%d)"
 	},
 	"is_not_an_admin": {
 		"en": "%s '%s' is not an admin.\n",
-		"ro": "%s '%s' nu este un admin.\n"
+		"ro": "%s '%s' nu este un admin.\n",
+		"es": "%s '%s' no es un administrador.\n"
 	},
 	"kick.message": {
 		"en": "%s %s kicked %s from server. Reason: %s\n",
-		"ro": "%s %s i-a dat kick lui %s de pe server. Motiv: %s\n"
+		"ro": "%s %s i-a dat kick lui %s de pe server. Motiv: %s\n",
+		"es": "%s %s expulsó a %s del servidor. Razón: %s\n"
 	},
 	"kick.syntax": {
 		"en": "%s Syntax: %skick <player> <reason>\n",
-		"ro": "%s Sintaxă: %skick <player> <motiv>\n"
+		"ro": "%s Sintaxă: %skick <player> <motiv>\n",
+		"es": "%s Sintaxis: %skick <jugador> <razón>\n"
 	},
 	"minutes": {
 		"en": "%.2f minute(s)",
-		"ro": "%.2f minut(e)"
+		"ro": "%.2f minut(e)",
+		"es": "%.2f minuto(s)"
 	},
 	"mute.message": {
 		"en": "%s %s muted %s for %s. Reason: %s\n",
-		"ro": "%s %s i-a dat mute lui %s pentru %s. Motiv: %s\n"
+		"ro": "%s %s i-a dat mute lui %s pentru %s. Motiv: %s\n",
+		"es": "%s %s silenció %s por %s. Razón: %s\n"
 	},
 	"mute.syntax": {
 		"en": "%s Syntax: %smute <player> <minutes / 0 - permanent> <reason>\n",
-		"ro": "%s Sintaxă: %smute <player> <minute / 0 - permanent> <motiv>\n"
+		"ro": "%s Sintaxă: %smute <player> <minute / 0 - permanent> <motiv>\n",
+		"es": "%s Sintaxis: %smute <jugador> <minutos / 0 - permanente> <razón>\n"
 	},
 	"mute_expired": {
 		"en": "%s Your mute has expired.",
-		"ro": "%s Mute-ul tău a expirat."
+		"ro": "%s Mute-ul tău a expirat.",
+		"es": "%s Tu silencio ha expirado."
 	},
 	"muted": {
 		"en": "%s You are muted. Expires in: %s. Reason: %s",
-		"ro": "%s Ai primit mute. Expiră în: %s. Motiv: %s"
+		"ro": "%s Ai primit mute. Expiră în: %s. Motiv: %s",
+		"es": "%s Estás silenciado. Expira en: %s. Razón: %s"
 	},
 	"never": {
 		"en": "Never",
-		"ro": "Niciodată"
+		"ro": "Niciodată",
+		"es": "Nunca"
 	},
 	"no_access": {
 		"en": "%s You don't have access to use this command.\n",
-		"ro": "%s Nu ai acces să folosești această comandă.\n"
+		"ro": "%s Nu ai acces să folosești această comandă.\n",
+		"es": "%s No tienes acceso para usar este comando.\n"
 	},
 	"player_already_gagged": {
 		"en": "%s %s is already gagged.\n",
-		"ro": "%s %s are deja gag.\n"
+		"ro": "%s %s are deja gag.\n",
+		"es": "%s %s ya está amordazado.\n"
 	},
 	"player_already_gagged_or_muted": {
 		"en": "%s %s is already gagged or muted.\n",
-		"ro": "%s %s are deja gag sau mute.\n"
+		"ro": "%s %s are deja gag sau mute.\n",
+		"es": "%s %s ya está amordazado o silenciado.\n"
 	},
 	"player_already_muted": {
 		"en": "%s %s is already muted.\n",
-		"ro": "%s %s are deja mute.\n"
+		"ro": "%s %s are deja mute.\n",
+		"es": "%s %s ya está silenciado.\n"
 	},
 	"player_not_connected": {
 		"en": "%s Player #%d is not connected on server.\n",
-		"ro": "%s Jucătorul #%d nu este conectat pe server.\n"
+		"ro": "%s Jucătorul #%d nu este conectat pe server.\n",
+		"es": "%s El jugador #%d no está conectado en el servidor.\n"
 	},
 	"player_not_gagged": {
 		"en": "%s %s is not gagged.\n",
-		"ro": "%s %s nu are gag.\n"
+		"ro": "%s %s nu are gag.\n",
+		"es": "%s %s no está amordazado.\n"
 	},
 	"player_not_gagged_and_muted": {
 		"en": "%s %s is not gagged and muted.\n",
-		"ro": "%s %s are nu are gag și mute.\n"
+		"ro": "%s %s are nu are gag și mute.\n",
+		"es": "%s %s no está amordazado y silenciado.\n"
 	},
 	"player_not_muted": {
 		"en": "%s %s is not muted.\n",
-		"ro": "%s %s nu are mute.\n"
+		"ro": "%s %s nu are mute.\n",
+		"es": "%s %s no está silenciado.\n"
 	},
 	"player_slayed": {
 		"en": "%s %s slayed %s.\n",
-		"ro": "%s %s l-a omorât pe %s.\n"
+		"ro": "%s %s l-a omorât pe %s.\n",
+		"es": "%s %s mató a %s.\n"
 	},
 	"psay.message": {
 		"en": "{green} (Private - Admin) To/From %s{default}: %s\n",
-		"ro": "{green} (Privat - Admin) Către/De la %s{default}: %s\n"
+		"ro": "{green} (Privat - Admin) Către/De la %s{default}: %s\n",
+		"es": "{green} (Privado - Admin) Para/De %s{default}: %s\n"
 	},
 	"psay.syntax": {
 		"en": "%s Syntax: %spsay <player> <message>\n",
-		"ro": "%s Sintaxă: %spsay <player> <mesaj>\n"
+		"ro": "%s Sintaxă: %spsay <player> <mesaj>\n",
+		"es": "%s Sintaxis: %spsay <jugador> <mensaje>\n"
 	},
 	"rcon.syntax": {
 		"en": "%s Syntax: %srcon <message>\n",
@@ -181,78 +225,97 @@
 	},
 	"reloadadmins": {
 		"en": "%s Admins has been succesfully reloaded.\n",
-		"ro": "%s Adminii au fost reîncărcați cu succes.\n"
+		"ro": "%s Adminii au fost reîncărcați cu succes.\n",
+		"es": "%s Los administradores han sido recargados con éxito.\n"
 	},
 	"removeadmin.message": {
 		"en": "%s %s removed '%s' from admin list.\n",
-		"ro": "%s %s l-a scos pe '%s' din lista de admini.\n"
+		"ro": "%s %s l-a scos pe '%s' din lista de admini.\n",
+		"es": "%s %s eliminó a '%s' de la lista de administradores.\n"
 	},
 	"removeadmin.syntax": {
 		"en": "%s Syntax: %sremoveadmin <steamid64>\n",
-		"ro": "%s Sintaxă: %sremoveadmin <steamid64>\n"
+		"ro": "%s Sintaxă: %sremoveadmin <steamid64>\n",
+		"es": "%s Sintaxis: %sremoveadmin <steamid64>\n"
 	},
 	"say.message": {
 		"en": "{green} (Admin) %s{default}: %s\n",
-		"ro": "{green} (Admin) %s{default}: %s\n"
+		"ro": "{green} (Admin) %s{default}: %s\n",
+		"es": "{green} (Admin) %s{default}: %s\n"
 	},
 	"say.syntax": {
 		"en": "%s Syntax: %ssay <message>\n",
-		"ro": "%s Sintaxă: %ssay <mesaj>\n"
+		"ro": "%s Sintaxă: %ssay <mesaj>\n",
+		"es": "%s Sintaxis: %ssay <mensaje>\n"
 	},
 	"seconds": {
 		"en": "%.2f second(s)",
-		"ro": "%.2f secunde"
+		"ro": "%.2f secunde",
+		"es": "%.2f segundo(s)"
 	},
 	"silence.message": {
 		"en": "%s %s silenced %s for %s. Reason: %s\n",
-		"ro": "%s %s i-a dat silence lui %s pentru %s. Motiv: %s\n"
+		"ro": "%s %s i-a dat silence lui %s pentru %s. Motiv: %s\n",
+		"es": "%s %s silenció %s por %s. Razón: %s\n"
 	},
 	"silence.syntax": {
 		"en": "%s Syntax: %ssilence <player> <minutes / 0 - permanent> <reason>\n",
-		"ro": "%s Sintaxă: %ssilence <player> <minute / 0 - permanent> <motiv>\n"
+		"ro": "%s Sintaxă: %ssilence <player> <minute / 0 - permanent> <motiv>\n",
+		"es": "%s Sintaxis: %ssilence <jugador> <minutos / 0 - permanente> <razón>\n"
 	},
 	"slap.message": {
 		"en": "%s %s slapped %s.\n",
-		"ro": "%s %s i-a dat slap lui %s.\n"
+		"ro": "%s %s i-a dat slap lui %s.\n",
+		"es": "%s %s abofeteó a %s.\n"
 	},
 	"slap.syntax": {
 		"en": "%s Syntax: %sslap <player>\n",
-		"ro": "%s Sintaxă: %sslap <player>\n"
+		"ro": "%s Sintaxă: %sslap <player>\n",
+		"es": "%s Sintaxis: %sslap <jugador>\n"
 	},
 	"slay.syntax": {
 		"en": "%s Syntax: %sslay <player>\n",
-		"ro": "%s Sintaxă: %sslay <player>\n"
+		"ro": "%s Sintaxă: %sslay <player>\n",
+		"es": "%s Sintaxis: %sslay <jugador>\n"
 	},
 	"unban.message": {
 		"en": "%s %s unbanned player with SteamID '%s'.\n",
-		"ro": "%s %s l-a debanat pe jucătorul cu SteamID-ul '%s'.\n"
+		"ro": "%s %s l-a debanat pe jucătorul cu SteamID-ul '%s'.\n",
+		"es": "%s %s desbaneó al jugador con SteamID '%s'.\n"
 	},
 	"unban.syntax": {
 		"en": "%s Syntax: %sunban <steamid>\n",
-		"ro": "%s Sintaxă: %sunban <steamid>\n"
+		"ro": "%s Sintaxă: %sunban <steamid>\n",
+		"es": "%s Sintaxis: %sunban <steamid>\n"
 	},
 	"ungag.message": {
 		"en": "%s %s ungagged %s.\n",
-		"ro": "%s %s i-a dat ungag lui %s.\n"
+		"ro": "%s %s i-a dat ungag lui %s.\n",
+		"es": "%s %s desamordazó a %s.\n"
 	},
 	"ungag.syntax": {
 		"en": "%s Syntax: %sungag <player>\n",
-		"ro": "%s Sintaxă: %sungag <player>\n"
+		"ro": "%s Sintaxă: %sungag <player>\n",
+		"es": "%s Sintaxis: %sungag <jugador>\n"
 	},
 	"unmute.message": {
 		"en": "%s %s unmuted %s.\n",
-		"ro": "%s %s i-a dat unmute lui %s.\n"
+		"ro": "%s %s i-a dat unmute lui %s.\n",
+		"es": "%s %s desilenció a %s.\n"
 	},
 	"unmute.syntax": {
 		"en": "%s Syntax: %sunmute <player>\n",
-		"ro": "%s Sintaxă: %sunmute <player>\n"
+		"ro": "%s Sintaxă: %sunmute <player>\n",
+		"es": "%s Sintaxis: %sunmute <jugador>\n"
 	},
 	"unsilence.message": {
 		"en": "%s %s unsilenced %s.\n",
-		"ro": "%s %s i-a dat unsilence lui %s.\n"
+		"ro": "%s %s i-a dat unsilence lui %s.\n",
+		"es": "%s %s desilenció a %s.\n"
 	},
 	"unsilence.syntax": {
 		"en": "%s Syntax: %sunsilence <player>\n",
-		"ro": "%s Sintaxă: %sunsilence <player>\n"
+		"ro": "%s Sintaxă: %sunsilence <player>\n",
+		"es": "%s Sintaxis: %sunsilence <jugador>\n"
 	}
 }

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -662,3 +662,61 @@ commands:Register("removeadmin", function(playerid, args, argc, silent)
     ReloadServerAdmins()
     print(string.format(FetchTranslation("admins.removeadmin.message"), config:Fetch("admins.prefix"), "CONSOLE", steamid))
 end)
+
+commands:Register("rr", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc > 1 then return print(string.format(FetchTranslation("admins.rr.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local time = tonumber(args[1])
+        if time == nil then time = 1 end
+        if time == 0 then
+            if restart_round then
+                print(string.format(FetchTranslation("admins.rr.cancel"), config:Fetch("admins.prefix"), "CONSOLE"))
+                playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rr.cancel"), config:Fetch("admins.prefix"), "CONSOLE"))
+                restart_round = false
+            else
+                print(string.format(FetchTranslation("admins.rr.no_restart"), config:Fetch("admins.prefix"), "CONSOLE"))
+                playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rr.no_restart"), config:Fetch("admins.prefix"), "CONSOLE"))
+            end
+        else
+            print(string.format(FetchTranslation("admins.rr.message"), config:Fetch("admins.prefix"), "CONSOLE", time))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rr.message"), config:Fetch("admins.prefix"), "CONSOLE", time))
+            restart_round = true
+            SetTimeout(time * 1000, function()
+                if restart_round then
+                    server:ExecuteCommand("sv_cheats 1; endround; sv_cheats 0;") -- Lazy way, but works.
+                    restart_round = false
+                end
+            end)
+        end
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc > 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rr.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local time = tonumber(args[1])
+        if time == nil then time = 1 end
+        if time == 0 then
+            if restart_round then
+                print(string.format(FetchTranslation("admins.rr.cancel"), config:Fetch("admins.prefix"), player:GetName()))
+                playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rr.cancel"), config:Fetch("admins.prefix"), player:GetName()))
+                restart_round = false
+            else
+                print(string.format(FetchTranslation("admins.rr.no_restart"), config:Fetch("admins.prefix"), player:GetName()))
+                playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rr.no_restart"), config:Fetch("admins.prefix"), player:GetName()))
+            end
+        else
+            print(string.format(FetchTranslation("admins.rr.message"), config:Fetch("admins.prefix"), player:GetName(), time))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rr.message"), config:Fetch("admins.prefix"), player:GetName(), time))
+            restart_round = true
+            SetTimeout(time * 1000, function()
+                if restart_round then
+                    server:ExecuteCommand("sv_cheats 1; endround; sv_cheats 0;") -- Lazy way, but works.
+                    restart_round = false
+                end
+            end)
+        end
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -748,3 +748,43 @@ commands:Register("rg", function(playerid, args, argc, silent)
         server:ExecuteCommand(string.format("mp_restartgame %d", time))
     end
 end)
+
+commands:Register("hp", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 2 then return print(string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local health = tonumber(args[2])
+        if health < 0 or health > 999 then return print(string.format(FetchTranslation("admins.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+
+        target:health():Set(health)
+        print(string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        local health = tonumber(args[2])
+        if health < 0 or health > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+
+        target:health():Set(health)
+        print(string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -790,7 +790,7 @@ commands:Register("hp", function(playerid, args, argc, silent)
         if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
 
         local health = tonumber(args[2])
-        if health < 0 or health > 999 then return print(string.format(FetchTranslation("admins.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+        if health < 0 or health > 999 then return print(string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
 
         target:health():Set(health)
         print(string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health))
@@ -811,7 +811,7 @@ commands:Register("hp", function(playerid, args, argc, silent)
         if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
 
         local health = tonumber(args[2])
-        if health < 0 or health > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+        if health < 0 or health > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
 
         target:health():Set(health)
         print(string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health))
@@ -830,7 +830,7 @@ commands:Register("team", function(playerid, args, argc, silent)
         if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
 
         local team = args[2]
-        if team ~= "ct" and team ~= "t" and team ~= "spec" then return print(string.format(FetchTranslation("admins.invalid_team"), config:Fetch("admins.prefix"))) end
+        if team ~= "ct" and team ~= "t" and team ~= "spec" then return print(string.format(FetchTranslation("admins.team.invalid_team"), config:Fetch("admins.prefix"))) end
 
         if team == "ct" then
             target:team():Set(TEAM_CT)
@@ -861,7 +861,7 @@ commands:Register("team", function(playerid, args, argc, silent)
         if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
 
         local team = args[2]
-        if team ~= "ct" and team ~= "t" and team ~= "spec" then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_team"), config:Fetch("admins.prefix"))) end
+        if team ~= "ct" and team ~= "t" and team ~= "spec" then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.team.invalid_team"), config:Fetch("admins.prefix"))) end
 
         if team == "ct" then
             target:team():Set(TEAM_CT)
@@ -993,7 +993,7 @@ commands:Register("give", function(playerid, args, argc, silent)
         if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
 
         local weapon = args[2]
-        if not IsValidWeapon("weapon_" .. weapon) then return print(string.format(FetchTranslation("admins.invalid_weapon"), config:Fetch("admins.prefix"))) end
+        if not IsValidWeapon("weapon_" .. weapon) then return print(string.format(FetchTranslation("admins.give.invalid_weapon"), config:Fetch("admins.prefix"))) end
 
         target:weapons():GiveWeapons("weapon_" .. weapon)
         print(string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), weapon))
@@ -1015,7 +1015,7 @@ commands:Register("give", function(playerid, args, argc, silent)
         if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
 
         local weapon = args[2]
-        if not IsValidWeapon("weapon_" .. weapon) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_weapon"), config:Fetch("admins.prefix"))) end
+        if not IsValidWeapon("weapon_" .. weapon) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.give.invalid_weapon"), config:Fetch("admins.prefix"))) end
 
         -- give the weapon to the target player (added weapon_ by default)
         target:weapons():GiveWeapons("weapon_" .. weapon)
@@ -1035,7 +1035,7 @@ commands:Register("giveitem", function(playerid, args, argc, silent)
         if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
 
         local item = args[2]
-        if not IsValidItem("item_" .. item) then return print(string.format(FetchTranslation("admins.invalid_item"), config:Fetch("admins.prefix"))) end
+        if not IsValidItem("item_" .. item) then return print(string.format(FetchTranslation("admins.giveitem.invalid_item"), config:Fetch("admins.prefix"))) end
 
         target:weapons():GiveWeapons("item_" .. item)
         print(string.format(FetchTranslation("admins.giveitem.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), item))
@@ -1057,7 +1057,7 @@ commands:Register("giveitem", function(playerid, args, argc, silent)
         if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
 
         local item = args[2]
-        if not IsValidItem("item_" .. item) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_item"), config:Fetch("admins.prefix"))) end
+        if not IsValidItem("item_" .. item) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.giveitem.invalid_item"), config:Fetch("admins.prefix"))) end
 
         -- give the item to the target player (added item_ by default)
         target:weapons():GiveWeapons("item_" .. item)
@@ -1143,7 +1143,7 @@ end)
 
 commands:Register("xyz", function(playerid, args, argc, silent)
     if playerid == -1 then
-        if argc > 1 then return print(string.format(FetchTranslation("admins.xyz.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+        if argc > 1 then return print(string.format(FetchTranslation("admins.xyz.syntax.server"), config:Fetch("admins.prefix"), "sw_")) end
 
         local targetid = GetPlayerId(args[1])
         if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
@@ -1151,29 +1151,19 @@ commands:Register("xyz", function(playerid, args, argc, silent)
         local target = GetPlayer(targetid)
         if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
 
-        local position = player:coords():Get()
-        print(string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), position.x, position.y, position.z))
-        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), position.x, position.y, position.z))
+        local position = target:coords():Get()
+        print(string.format(FetchTranslation("admins.xyz.message.server"), config:Fetch("admins.prefix"), target:GetName(), position))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), position))
     else
+        -- for client: !xyz. This will show the player's current position.
         local player = GetPlayer(playerid)
         if not player then return end
 
-        if argc > 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
 
-        local targetid = GetPlayerId(args[1])
-        if targetid == -1 then
-            if argc > 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+        if argc > 0 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.syntax.client"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
 
-            local position = player:coords():Get()
-            print(string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), player:GetName(), position.x, position.y, position.z))
-            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), player:GetName(), position.x, position.y, position.z))
-        else
-            local target = GetPlayer(targetid)
-            if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
-
-            local position = target:coords():Get()
-            print(string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), position.x, position.y, position.z))
-            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), position.x, position.y, position.z))
-        end
+        local position = player:coords():Get()
+        player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message.client"), config:Fetch("admins.prefix"), position))
     end
 end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1070,3 +1070,43 @@ commands:Register("melee", function(playerid, args, argc, silent)
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.melee.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
     end
 end)
+
+commands:Register("disarm", function(playerid, args, argc, silent) -- diff with !melee is that this one doesn't left u with knife -> weapon:Remove()
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.disarm.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        target:weapons():RemoveWeapons()
+        print(string.format(FetchTranslation("admins.disarm.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.disarm.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.disarm.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        target:weapons():RemoveWeapons()
+        -- check left weapon
+        local currentweapon = player:weapons():GetWeaponFromSlot(WeaponSlot.CurrentWeapon)
+        if currentweapon then
+            currentweapon:Remove()
+        end
+        print(string.format(FetchTranslation("admins.disarm.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.disarm.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -869,8 +869,8 @@ commands:Register("hp", function(playerid, args, argc, silent) -- !hp <#userid|n
 
         if not PlayerHasFlag(player, ADMFLAG_SLAY) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
         if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
-       
-        -- currently argc > 3 to disable helmet feature, set to argc == 4 to enable helmet feature
+
+        -- NOTE: currently argc > 3 to disable helmet feature, set to argc == 4 to enable helmet feature in the future.
         if argc > 3 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
 
         local targetid = GetPlayerId(args[1])
@@ -911,7 +911,7 @@ commands:Register("hp", function(playerid, args, argc, silent) -- !hp <#userid|n
 
             if helmet == 1 then target:weapons():GiveWeapons("item_assaultsuit") 
             elseif helmet == 0 then
-                -- TODO: Remove helmet feature
+                -- TODO: Remove helmet feature (missing method)
             end
             target:armor():Set(armor)
             print(string.format(FetchTranslation("admins.hp.message3"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health, armor, helmet))

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -726,12 +726,27 @@ commands:Register("rg", function(playerid, args, argc, silent)
         if argc > 1 then return print(string.format(FetchTranslation("admins.rg.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
         local time = tonumber(args[1])
-        if time == nil then time = 1
-        elseif time < 0 then time = 0 end
-
-        print(string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), "CONSOLE", time))
-        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), "CONSOLE", time))
-        server:ExecuteCommand(string.format("mp_restartgame %d", time))
+        if time == nil then time = 1 end
+        if time == 0 then
+            if restart_game then
+                print(string.format(FetchTranslation("admins.rg.cancel"), config:Fetch("admins.prefix"), "CONSOLE"))
+                playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.cancel"), config:Fetch("admins.prefix"), "CONSOLE"))
+                restart_game = false
+            else
+                print(string.format(FetchTranslation("admins.rg.no_restart"), config:Fetch("admins.prefix"), "CONSOLE"))
+                playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.no_restart"), config:Fetch("admins.prefix"), "CONSOLE"))
+            end
+        else
+            print(string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), "CONSOLE", time))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), "CONSOLE", time))
+            restart_game = true
+            SetTimeout(time * 1000, function()
+                if restart_game then
+                    server:ExecuteCommand("mp_restartgame 1")
+                    restart_game = false
+                end
+            end)
+        end
     else
         local player = GetPlayer(playerid)
         if not player then return end
@@ -740,12 +755,27 @@ commands:Register("rg", function(playerid, args, argc, silent)
         if argc > 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
 
         local time = tonumber(args[1])
-        if time == nil then time = 1
-        elseif time < 0 then time = 0 end
-
-        print(string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), player:GetName(), time))
-        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), player:GetName(), time))
-        server:ExecuteCommand(string.format("mp_restartgame %d", time))
+        if time == nil then time = 1 end
+        if time == 0 then
+            if restart_game then
+                print(string.format(FetchTranslation("admins.rg.cancel"), config:Fetch("admins.prefix"), player:GetName()))
+                playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.cancel"), config:Fetch("admins.prefix"), player:GetName()))
+                restart_game = false
+            else
+                print(string.format(FetchTranslation("admins.rg.no_restart"), config:Fetch("admins.prefix"), player:GetName()))
+                playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.no_restart"), config:Fetch("admins.prefix"), player:GetName()))
+            end
+        else
+            print(string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), player:GetName(), time))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), player:GetName(), time))
+            restart_game = true
+            SetTimeout(time * 1000, function()
+                if restart_game then
+                    server:ExecuteCommand("mp_restartgame 1")
+                    restart_game = false
+                end
+            end)
+        end
     end
 end)
 

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1101,7 +1101,7 @@ commands:Register("disarm", function(playerid, args, argc, silent) -- diff with 
         if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
 
         target:weapons():RemoveWeapons()
-        -- check left weapon
+        -- check remaining weapons and remove them
         local currentweapon = player:weapons():GetWeaponFromSlot(WeaponSlot.CurrentWeapon)
         if currentweapon then
             currentweapon:Remove()

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1143,6 +1143,7 @@ end)
 
 commands:Register("xyz", function(playerid, args, argc, silent)
     if playerid == -1 then
+        -- for server: sw_xyz. This will show the player's current position.
         if argc > 1 then return print(string.format(FetchTranslation("admins.xyz.syntax.server"), config:Fetch("admins.prefix"), "sw_")) end
 
         local targetid = GetPlayerId(args[1])
@@ -1152,8 +1153,7 @@ commands:Register("xyz", function(playerid, args, argc, silent)
         if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
 
         local position = target:coords():Get()
-        print(string.format(FetchTranslation("admins.xyz.message.server"), config:Fetch("admins.prefix"), target:GetName(), position))
-        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), position))
+        print(string.format(FetchTranslation("admins.xyz.message.server"), config:Fetch("admins.prefix"), target:GetName(), position.x, position.y, position.z))
     else
         -- for client: !xyz. This will show the player's current position.
         local player = GetPlayer(playerid)
@@ -1164,6 +1164,6 @@ commands:Register("xyz", function(playerid, args, argc, silent)
         if argc > 0 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.syntax.client"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
 
         local position = player:coords():Get()
-        player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message.client"), config:Fetch("admins.prefix"), position))
+        player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message.client"), config:Fetch("admins.prefix"), position.x, position.y, position.z))
     end
 end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -896,3 +896,37 @@ commands:Register("swap", function(playerid, args, argc, silent)
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.swap.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
     end
 end)
+
+commands:Register("respawn", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.respawn.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        target:Respawn()
+        print(string.format(FetchTranslation("admins.respawn.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.respawn.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.respawn.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        target:Respawn()
+        print(string.format(FetchTranslation("admins.respawn.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.respawn.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -526,7 +526,7 @@ commands:Register("unsilence", function(playerid, args, argc, silent)
     end
 end)
 
-commands:Register("slap", function(playerid, args, argc, silent) -- !slap <player> <optionaldamage>
+commands:Register("slap", function(playerid, args, argc, silent)
     if playerid == -1 then
         if argc < 1 then return print(string.format(FetchTranslation("admins.slap.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
@@ -819,7 +819,7 @@ commands:Register("rg", function(playerid, args, argc, silent)
     end
 end)
 
-commands:Register("hp", function(playerid, args, argc, silent) -- !hp <#userid|name|steamid|targetid> [health] [armor (optional)] [helmet=1/0 (optional)]
+commands:Register("hp", function(playerid, args, argc, silent) -- !hp <#userid|name|steamid|targetid> [health] [armor (optional)] [helmet=1/0 (optional)] => WIP 90% done.
     if playerid == -1 then
         if argc < 2 then return print(string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
@@ -869,7 +869,8 @@ commands:Register("hp", function(playerid, args, argc, silent) -- !hp <#userid|n
 
         if not PlayerHasFlag(player, ADMFLAG_SLAY) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
         if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
-        -- currently argc > 3 for disable helmet feature
+       
+        -- currently argc > 3 to disable helmet feature, set to argc == 4 to enable helmet feature
         if argc > 3 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
 
         local targetid = GetPlayerId(args[1])
@@ -1117,7 +1118,6 @@ commands:Register("give", function(playerid, args, argc, silent)
         local weapon = args[2]
         if not IsValidWeapon("weapon_" .. weapon) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.give.invalid_weapon"), config:Fetch("admins.prefix"))) end
 
-        -- give the weapon to the target player (added weapon_ by default)
         target:weapons():GiveWeapons("weapon_" .. weapon)
         print(string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), weapon))
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), weapon))
@@ -1159,7 +1159,6 @@ commands:Register("giveitem", function(playerid, args, argc, silent)
         local item = args[2]
         if not IsValidItem("item_" .. item) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.giveitem.invalid_item"), config:Fetch("admins.prefix"))) end
 
-        -- give the item to the target player (added item_ by default)
         target:weapons():GiveWeapons("item_" .. item)
         print(string.format(FetchTranslation("admins.giveitem.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), item))
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.giveitem.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), item))
@@ -1201,7 +1200,7 @@ commands:Register("melee", function(playerid, args, argc, silent)
     end
 end)
 
-commands:Register("disarm", function(playerid, args, argc, silent) -- diff with !melee is that this one doesn't left u with knife -> weapon:Remove()
+commands:Register("disarm", function(playerid, args, argc, silent)
     if playerid == -1 then
         if argc < 1 then return print(string.format(FetchTranslation("admins.disarm.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
@@ -1231,7 +1230,6 @@ commands:Register("disarm", function(playerid, args, argc, silent) -- diff with 
         if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
 
         target:weapons():RemoveWeapons()
-        -- check remaining weapons and remove them
         local currentweapon = player:weapons():GetWeaponFromSlot(WeaponSlot.CurrentWeapon)
         if currentweapon then
             currentweapon:Remove()
@@ -1243,7 +1241,6 @@ end)
 
 commands:Register("xyz", function(playerid, args, argc, silent)
     if playerid == -1 then
-        -- for server: sw_xyz <player>. This will show the player's current position.
         if argc > 1 then return print(string.format(FetchTranslation("admins.xyz.syntax.server"), config:Fetch("admins.prefix"), "sw_")) end
 
         local targetid = GetPlayerId(args[1])
@@ -1255,7 +1252,6 @@ commands:Register("xyz", function(playerid, args, argc, silent)
         local position = target:coords():Get()
         print(string.format(FetchTranslation("admins.xyz.message.server"), config:Fetch("admins.prefix"), target:GetName(), position.x, position.y, position.z))
     else
-        -- for client: !xyz. This will show your position.
         local player = GetPlayer(playerid)
         if not player then return end
 
@@ -1352,9 +1348,6 @@ commands:Register("armor", function(playerid, args, argc, silent)
     end
 end)
 
--- From here to the end of the file, the commands are WIP and need to be tested or maybe contain bugs.
-
--- respawn 1up player (if dead, respawns in the same position).
 commands:Register("1up", function(playerid, args, argc, silent)
     if playerid == -1 then
         if argc < 1 then return print(string.format(FetchTranslation("admins.1up.syntax"), config:Fetch("admins.prefix"), "sw_")) end
@@ -1406,7 +1399,7 @@ commands:Register("1up", function(playerid, args, argc, silent)
     end
 end)
 
-commands:Register("tele", function(playerid, args, argc, silent) -- !tele <playerFrom> <playerTo>
+commands:Register("tele", function(playerid, args, argc, silent)
     if playerid == -1 then
         if argc < 2 then return print(string.format(FetchTranslation("admins.tele.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
@@ -1459,7 +1452,7 @@ commands:Register("tele", function(playerid, args, argc, silent) -- !tele <playe
     end
 end)
 
-commands:Register("bring", function(playerid, args, argc, silent) -- bring a player to me. !bring <player>
+commands:Register("bring", function(playerid, args, argc, silent)
     if playerid == -1 then
         if argc < 1 then return print(string.format(FetchTranslation("admins.bring.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
@@ -1500,7 +1493,7 @@ commands:Register("bring", function(playerid, args, argc, silent) -- bring a pla
     end
 end)
 
-commands:Register("goto", function(playerid, args, argc, silent) -- go to a player. !goto <player>
+commands:Register("goto", function(playerid, args, argc, silent)
     if playerid == -1 then
         if argc < 1 then return print(string.format(FetchTranslation("admins.goto.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
@@ -1538,5 +1531,63 @@ commands:Register("goto", function(playerid, args, argc, silent) -- go to a play
 
         print(string.format(FetchTranslation("admins.goto.message"), config:Fetch("admins.prefix"), player:GetName(), GetPlayer(playerid):GetName(), target:GetName()))
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.goto.message"), config:Fetch("admins.prefix"), player:GetName(), GetPlayer(playerid):GetName(), target:GetName()))
+    end
+end)
+
+commands:Register("noclip", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.noclip.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("noclip") == 1 then
+            target:vars():Set("noclip", 0)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_WALK)
+            local entity = entities:Create("player:" .. targetid)
+            entity:SetCollisionGroup(CollisionGroup.Default)
+            print(string.format(FetchTranslation("admins.noclip.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.disabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.noclip.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.disabled")))
+        else
+            target:vars():Set("noclip", 1)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_NOCLIP)
+            local entity = entities:Create("player:" .. targetid)
+            entity:SetCollisionGroup(CollisionGroup.In_Vehicle)
+            print(string.format(FetchTranslation("admins.noclip.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.enabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.noclip.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.enabled")))
+        end
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.noclip.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        if target:vars():Get("noclip") == 1 then
+            target:vars():Set("noclip", 0)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_WALK)
+            local entity = entities:Create("player:" .. targetid)
+            entity:SetCollisionGroup(CollisionGroup.Default)
+            print(string.format(FetchTranslation("admins.noclip.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.disabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.noclip.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.disabled")))
+        else
+            target:vars():Set("noclip", 1)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_NOCLIP)
+            local entity = entities:Create("player:" .. targetid)
+            entity:SetCollisionGroup(CollisionGroup.In_Vehicle)
+            print(string.format(FetchTranslation("admins.noclip.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.enabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.noclip.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.enabled")))
+        end
     end
 end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -952,7 +952,7 @@ commands:Register("cc", function(playerid, args, argc, silent)
     end
 end)
 
-commands:Register("give", function(playerid, args, argc, silent) -- usage /give <player> <weapon>; example: /give crisky ak47
+commands:Register("give", function(playerid, args, argc, silent)
     if playerid == -1 then
         if argc < 2 then return print(string.format(FetchTranslation("admins.give.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
@@ -972,24 +972,18 @@ commands:Register("give", function(playerid, args, argc, silent) -- usage /give 
         local player = GetPlayer(playerid)
         if not player then return end
 
-        -- check if player has access to the command
         if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
 
-        -- check if player has entered the correct arguments
         if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.give.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
 
-        -- check if the target player is valid
         local targetid = GetPlayerId(args[1])
         if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
 
-        -- get the target player
         local target = GetPlayer(targetid)
         if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
 
-        -- check if the target player has a higher immunity level
         if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
 
-        -- check if the weapon is valid
         local weapon = args[2]
         if not IsValidWeapon("weapon_" .. weapon) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_weapon"), config:Fetch("admins.prefix"))) end
 
@@ -997,5 +991,47 @@ commands:Register("give", function(playerid, args, argc, silent) -- usage /give 
         target:weapons():GiveWeapons("weapon_" .. weapon)
         print(string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), weapon))
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), weapon))
+    end
+end)
+
+commands:Register("giveitem", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 2 then return print(string.format(FetchTranslation("admins.giveitem.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local item = args[2]
+        if not IsValidItem("item_" .. item) then return print(string.format(FetchTranslation("admins.invalid_item"), config:Fetch("admins.prefix"))) end
+
+        target:weapons():GiveWeapons("item_" .. item)
+        print(string.format(FetchTranslation("admins.giveitem.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), item))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.giveitem.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), item))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+
+        if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.giveitem.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        local item = args[2]
+        if not IsValidItem("item_" .. item) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_item"), config:Fetch("admins.prefix"))) end
+
+        -- give the item to the target player (added item_ by default)
+        target:weapons():GiveWeapons("item_" .. item)
+        print(string.format(FetchTranslation("admins.giveitem.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), item))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.giveitem.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), item))
     end
 end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1464,7 +1464,7 @@ commands:Register("bring", function(playerid, args, argc, silent)
 
         local position = GetPlayer(playerid):coords():Get()
         
-        target:coords():Set(position + vector3(0, 0, 100))
+        target:coords():Set(position + vector3(0, 0, 300))
 
         print(string.format(FetchTranslation("admins.bring.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.bring.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
@@ -1486,7 +1486,7 @@ commands:Register("bring", function(playerid, args, argc, silent)
 
         local position = player:coords():Get()
         
-        target:coords():Set(position + vector3(0, 0, 100))
+        target:coords():Set(position + vector3(0, 0, 300))
 
         print(string.format(FetchTranslation("admins.bring.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.bring.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
@@ -1591,3 +1591,300 @@ commands:Register("noclip", function(playerid, args, argc, silent)
         end
     end
 end)
+
+commands:Register("freeze", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.freeze.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("freeze") == 1 then
+            target:vars():Set("freeze", 0)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_WALK)
+            print(string.format(FetchTranslation("admins.freeze.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.disabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.freeze.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.disabled")))
+        else
+            target:vars():Set("freeze", 1)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_NONE)
+            print(string.format(FetchTranslation("admins.freeze.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.enabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.freeze.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.enabled")))
+        end
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.freeze.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        if target:vars():Get("freeze") == 1 then
+            print(string.format(FetchTranslation("admins.player_already_freezed"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_already_freezed"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        else
+            target:vars():Set("freeze", 1)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_NONE)
+            print(string.format(FetchTranslation("admins.freeze.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.enabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.freeze.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.enabled")))
+        end
+    end
+end) 
+
+commands:Register("unfreeze", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.unfreeze.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("freeze") == 0 then
+            print(string.format(FetchTranslation("admins.player_not_freezed"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_freezed"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+        else
+            target:vars():Set("freeze", 0)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_WALK)
+            print(string.format(FetchTranslation("admins.freeze.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.disabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.freeze.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.disabled")))
+        end
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.unfreeze.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        if target:vars():Get("freeze") == 0 then
+            print(string.format(FetchTranslation("admins.player_not_freezed"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_freezed"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        else
+            target:vars():Set("freeze", 0)
+            target:SetActualMoveType(MoveType_t.MOVETYPE_WALK)
+            print(string.format(FetchTranslation("admins.unfreeze.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.disabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.unfreeze.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.disabled")))
+        end
+    end
+end)
+
+commands:Register("bury", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.bury.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local position = target:coords():Get()
+        
+        target:coords():Set(position + vector3(0, 0, -30))
+
+        print(string.format(FetchTranslation("admins.bury.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.bury.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+    else
+        player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.bury.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        local position = target:coords():Get()
+        
+        target:coords():Set(position + vector3(0, 0, -30))
+
+        print(string.format(FetchTranslation("admins.bury.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.bury.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+    end
+end)
+
+commands:Register("unbury", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.unbury.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local position = target:coords():Get()
+        
+        target:coords():Set(position + vector3(0, 0, 10))
+
+        print(string.format(FetchTranslation("admins.unbury.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.unbury.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+    else
+        player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.unbury.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        local position = target:coords():Get()
+        
+        target:coords():Set(position + vector3(0, 0, 10))
+
+        print(string.format(FetchTranslation("admins.unbury.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.unbury.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+    end
+end)
+
+commands:Register("uslap", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.uslap.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        -- if times not specified then slap 15 times
+        if argc == 1 then args[2] = "15" end
+
+        local times = tonumber(args[2])
+        if times < 1 or times > 100 then return print(string.format(FetchTranslation("admins.uslap.invalid_times"), config:Fetch("admins.prefix"), 1, 100)) end
+
+        local damage = 0
+        if argc > 2 then
+            damage = tonumber(args[3])
+            if damage < 0 or damage > 1000 then return print(string.format(FetchTranslation("admins.uslap.invalid_damage"), config:Fetch("admins.prefix"), 0, 1000)) end
+        end
+
+        for i = 1, times do
+            SetTimeout(i * 250, function()
+
+                local vel = target:velocity():Get()
+                vel.x = vel.x + math.random(50, 230) * (math.random(0, 1) == 1 and -1 or 1)
+                vel.y = vel.y + math.random(50, 230) * (math.random(0, 1) == 1 and -1 or 1)
+                vel.z = vel.z + math.random(100, 300)
+        
+                target:velocity():Set(vel)
+
+                target:health():Set(target:health():Get() - damage)
+                if target:health():Get() <= 0 then
+                    target:Kill()
+                end
+            end)
+        end
+
+        print(string.format(FetchTranslation("admins.uslap.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), times, damage))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.uslap.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), times, damage))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.uslap.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+        
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+        
+        -- if times not specified then slap 15 times
+        if argc == 1 then args[2] = "15" end
+
+        local times = tonumber(args[2])
+        if times < 1 or times > 100 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.uslap.invalid_times"), config:Fetch("admins.prefix"), 1, 100)) end
+
+        local damage = 0
+        if argc > 2 then
+            damage = tonumber(args[3])
+            if damage < 0 or damage > 1000 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.uslap.invalid_damage"), config:Fetch("admins.prefix"), 0, 1000)) end
+        end
+
+        for i = 1, times do
+            SetTimeout(i * 250, function()
+
+                local vel = target:velocity():Get()
+                vel.x = vel.x + math.random(50, 230) * (math.random(0, 1) == 1 and -1 or 1)
+                vel.y = vel.y + math.random(50, 230) * (math.random(0, 1) == 1 and -1 or 1)
+                vel.z = vel.z + math.random(100, 300)
+        
+                target:velocity():Set(vel)
+
+                target:health():Set(target:health():Get() - damage)
+                if target:health():Get() <= 0 then
+                    target:Kill()
+                end
+            end)
+        end
+
+        print(string.format(FetchTranslation("admins.uslap.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), times, damage))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.uslap.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), times, damage))
+    end
+end)
+
+--[[
+commands:Register("rename", function(playerid, args, argc, silent) -- wip
+    if playerid == -1 then
+        -- server logic
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rename.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent), "NewName")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+        
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        local name = args[2]
+        if name == target:GetName() then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rename.same_name"), config:Fetch("admins.prefix"), target:GetName())) end
+
+        target:SetName("1") -- remove previous name
+        target:SetName(name)
+
+        print(string.format(FetchTranslation("admins.rename.message"), config:Fetch("admins.prefix"), player:GetName(), args[1], name))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rename.message"), config:Fetch("admins.prefix"), player:GetName(), args[1], name))
+    end
+end)
+]]

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1167,3 +1167,47 @@ commands:Register("xyz", function(playerid, args, argc, silent)
         player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message.client"), config:Fetch("admins.prefix"), position.x, position.y, position.z))
     end
 end)
+
+commands:Register("god", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.god.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("godmode") == 1 then
+            target:vars():Set("godmode", 0)
+            print(string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.disabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.disabled")))
+        else
+            target:vars():Set("godmode", 1)
+            print(string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.enabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), FetchTranslation("admins.enabled")))
+        end
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.god.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("godmode") == 1 then
+            target:vars():Set("godmode", 0)
+            print(string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.disabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.disabled")))
+        else
+            target:vars():Set("godmode", 1)
+            print(string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.enabled")))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.enabled")))
+        end
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1110,3 +1110,40 @@ commands:Register("disarm", function(playerid, args, argc, silent) -- diff with 
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.disarm.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
     end
 end)
+
+commands:Register("xyz", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc > 1 then return print(string.format(FetchTranslation("admins.xyz.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local position = player:coords():Get()
+        print(string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), position.x, position.y, position.z))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), position.x, position.y, position.z))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if argc > 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then
+            if argc > 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+            local position = player:coords():Get()
+            print(string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), player:GetName(), position.x, position.y, position.z))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), player:GetName(), position.x, position.y, position.z))
+        else
+            local target = GetPlayer(targetid)
+            if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+            local position = target:coords():Get()
+            print(string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), position.x, position.y, position.z))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.xyz.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), position.x, position.y, position.z))
+        end
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -930,3 +930,24 @@ commands:Register("respawn", function(playerid, args, argc, silent)
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.respawn.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
     end
 end)
+
+commands:Register("cc", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        for i = 1, 20 do
+            playermanager:SendMsg(MessageType.Chat, " \x01\x0B \x0B ")
+        end
+        print(string.format(FetchTranslation("admins.cc.message"), config:Fetch("admins.prefix"), "CONSOLE"))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cc.message"), config:Fetch("admins.prefix"), "CONSOLE"))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_CHAT) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+
+        for i = 1, 20 do
+            playermanager:SendMsg(MessageType.Chat, " \x01\x0B \x0B ", player)
+        end
+        print(string.format(FetchTranslation("admins.cc.message"), config:Fetch("admins.prefix"), player:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cc.message"), config:Fetch("admins.prefix"), player:GetName()))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1311,3 +1311,37 @@ commands:Register("armor", function(playerid, args, argc, silent)
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.armor.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), armor))
     end
 end)
+
+-- respawn 1up player (if dead, respawns in the same position) WIP
+commands:Register("1up", function(playerid, args, argc, silent)
+    if playerid == -1 then
+-- server logic
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.1up.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        local position = target:vars():Get("deathposition")
+        if position == "nil" then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.1up.no_death_position"), config:Fetch("admins.prefix"), target:GetName())) end
+
+        target:Respawn()
+
+        NextTick(function()
+            target:coords():Set(toVector3(position))
+        end)
+
+        print(string.format(FetchTranslation("admins.1up.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.1up.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -720,3 +720,31 @@ commands:Register("rr", function(playerid, args, argc, silent)
         end
     end
 end)
+
+commands:Register("rg", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc > 1 then return print(string.format(FetchTranslation("admins.rg.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local time = tonumber(args[1])
+        if time == nil then time = 1
+        elseif time < 0 then time = 0 end
+
+        print(string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), "CONSOLE", time))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), "CONSOLE", time))
+        server:ExecuteCommand(string.format("mp_restartgame %d", time))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc > 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local time = tonumber(args[1])
+        if time == nil then time = 1
+        elseif time < 0 then time = 0 end
+
+        print(string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), player:GetName(), time))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rg.message"), config:Fetch("admins.prefix"), player:GetName(), time))
+        server:ExecuteCommand(string.format("mp_restartgame %d", time))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -951,3 +951,51 @@ commands:Register("cc", function(playerid, args, argc, silent)
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cc.message"), config:Fetch("admins.prefix"), player:GetName()))
     end
 end)
+
+commands:Register("give", function(playerid, args, argc, silent) -- usage /give <player> <weapon>; example: /give crisky ak47
+    if playerid == -1 then
+        if argc < 2 then return print(string.format(FetchTranslation("admins.give.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local weapon = args[2]
+        if not IsValidWeapon("weapon_" .. weapon) then return print(string.format(FetchTranslation("admins.invalid_weapon"), config:Fetch("admins.prefix"))) end
+
+        target:weapons():GiveWeapons("weapon_" .. weapon)
+        print(string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), weapon))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), weapon))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        -- check if player has access to the command
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+
+        -- check if player has entered the correct arguments
+        if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.give.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        -- check if the target player is valid
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        -- get the target player
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        -- check if the target player has a higher immunity level
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        -- check if the weapon is valid
+        local weapon = args[2]
+        if not IsValidWeapon("weapon_" .. weapon) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_weapon"), config:Fetch("admins.prefix"))) end
+
+        -- give the weapon to the target player (added weapon_ by default)
+        target:weapons():GiveWeapons("weapon_" .. weapon)
+        print(string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), weapon))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.give.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), weapon))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1858,10 +1858,23 @@ commands:Register("uslap", function(playerid, args, argc, silent)
     end
 end)
 
---[[
-commands:Register("rename", function(playerid, args, argc, silent) -- wip
+commands:Register("rename", function(playerid, args, argc, silent)
     if playerid == -1 then
-        -- server logic
+        if argc < 2 then return print(string.format(FetchTranslation("admins.rename.syntax"), config:Fetch("admins.prefix"), "sw_", "NewName")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local name = args[2]
+        if name == target:GetName() then return print(string.format(FetchTranslation("admins.rename.same_name"), config:Fetch("admins.prefix"), target:GetName())) end
+
+        target:SetName(name)
+
+        print(string.format(FetchTranslation("admins.rename.message"), config:Fetch("admins.prefix"), "CONSOLE", args[1], name))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rename.message"), config:Fetch("admins.prefix"), "CONSOLE", args[1], name))
     else
         local player = GetPlayer(playerid)
         if not player then return end
@@ -1880,11 +1893,9 @@ commands:Register("rename", function(playerid, args, argc, silent) -- wip
         local name = args[2]
         if name == target:GetName() then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rename.same_name"), config:Fetch("admins.prefix"), target:GetName())) end
 
-        target:SetName("1") -- remove previous name
         target:SetName(name)
 
         print(string.format(FetchTranslation("admins.rename.message"), config:Fetch("admins.prefix"), player:GetName(), args[1], name))
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.rename.message"), config:Fetch("admins.prefix"), player:GetName(), args[1], name))
     end
 end)
-]]

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -848,3 +848,51 @@ commands:Register("team", function(playerid, args, argc, silent)
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.team.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), team))
     end
 end)
+
+commands:Register("swap", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.swap.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:team():Get() == TEAM_CT then
+            target:team():Set(TEAM_T)
+            target:Respawn()
+        elseif target:team():Get() == TEAM_T then
+            target:team():Set(TEAM_CT)
+            target:Respawn()
+        end
+
+        print(string.format(FetchTranslation("admins.swap.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.swap.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.swap.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        if target:team():Get() == TEAM_CT then
+            target:team():Set(TEAM_T)
+            target:Respawn()
+        elseif target:team():Get() == TEAM_T then
+            target:team():Set(TEAM_CT)
+            target:Respawn()
+        end
+
+        print(string.format(FetchTranslation("admins.swap.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.swap.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -1035,3 +1035,38 @@ commands:Register("giveitem", function(playerid, args, argc, silent)
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.giveitem.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), item))
     end
 end)
+
+commands:Register("melee", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 1 then return print(string.format(FetchTranslation("admins.melee.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        target:weapons():RemoveWeapons()
+        print(string.format(FetchTranslation("admins.melee.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.melee.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName()))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+
+        if argc < 1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.melee.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        target:weapons():RemoveWeapons()
+        print(string.format(FetchTranslation("admins.melee.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.melee.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName()))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -788,3 +788,63 @@ commands:Register("hp", function(playerid, args, argc, silent)
         playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health))
     end
 end)
+
+commands:Register("team", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 2 then return print(string.format(FetchTranslation("admins.team.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local team = args[2]
+        if team ~= "ct" and team ~= "t" and team ~= "spec" then return print(string.format(FetchTranslation("admins.invalid_team"), config:Fetch("admins.prefix"))) end
+
+        if team == "ct" then
+            target:team():Set(TEAM_CT)
+            target:Respawn()
+        elseif team == "t" then
+            target:team():Set(TEAM_T)
+            target:Respawn()
+        elseif team == "spec" then
+            target:team():Set(TEAM_SPEC)
+            target:Respawn()
+        end
+
+        print(string.format(FetchTranslation("admins.team.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), team))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.team.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), team))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.team.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        local team = args[2]
+        if team ~= "ct" and team ~= "t" and team ~= "spec" then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_team"), config:Fetch("admins.prefix"))) end
+
+        if team == "ct" then
+            target:team():Set(TEAM_CT)
+            target:Respawn()
+        elseif team == "t" then
+            target:team():Set(TEAM_T)
+            target:Respawn()
+        elseif team == "spec" then
+            target:team():Set(TEAM_SPEC)
+            target:Respawn()
+        end
+
+        print(string.format(FetchTranslation("admins.team.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), team))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.team.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), team))
+    end
+end)

--- a/src/modules/Commands.lua
+++ b/src/modules/Commands.lua
@@ -779,7 +779,7 @@ commands:Register("rg", function(playerid, args, argc, silent)
     end
 end)
 
-commands:Register("hp", function(playerid, args, argc, silent)
+commands:Register("hp", function(playerid, args, argc, silent) -- !hp <#userid|name|steamid|targetid> [health] [armor (optional)] [helmet=1/0 (optional)]
     if playerid == -1 then
         if argc < 2 then return print(string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), "sw_")) end
 
@@ -788,19 +788,49 @@ commands:Register("hp", function(playerid, args, argc, silent)
 
         local target = GetPlayer(targetid)
         if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+        
+        if argc == 2 then
+            local health = tonumber(args[2])
+            if health < 0 or health > 999 then return print(string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+            target:health():Set(health)
+            print(string.format(FetchTranslation("admins.hp.message1"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message1"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health))
+        elseif argc == 3 then
+            local health = tonumber(args[2])
+            if health < 0 or health > 999 then return print(string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+            target:health():Set(health)
 
-        local health = tonumber(args[2])
-        if health < 0 or health > 999 then return print(string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+            local armor = tonumber(args[3])
+            if armor < 0 or armor > 999 then return print(string.format(FetchTranslation("admins.hp.invalid_armor"), config:Fetch("admins.prefix"), 0, 999)) end
+            target:armor():Set(armor)
 
-        target:health():Set(health)
-        print(string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health))
-        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health))
+            print(string.format(FetchTranslation("admins.hp.message2"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health, armor))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message2"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health, armor))
+        elseif argc == 4 then
+            local health = tonumber(args[2])
+            if health < 0 or health > 999 then return print(string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+            target:health():Set(health)
+
+            local armor = tonumber(args[3])
+            if armor < 0 or armor > 999 then return print(string.format(FetchTranslation("admins.hp.invalid_armor"), config:Fetch("admins.prefix"), 0, 999)) end
+
+            local helmet = tonumber(args[4])
+            if helmet < 0 or helmet > 1 then return print(string.format(FetchTranslation("admins.hp.invalid_helmet"), config:Fetch("admins.prefix"), 0, 1)) end
+
+            if helmet == 1 then target:weapons():GiveWeapons("item_assaultsuit") 
+            elseif helmet == 0 then target:armor():Set("0") end
+            target:armor():Set(armor)
+            print(string.format(FetchTranslation("admins.hp.message3"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health, armor, helmet))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message3"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), health, armor, helmet))
+        end
     else
         local player = GetPlayer(playerid)
         if not player then return end
 
-        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if not PlayerHasFlag(player, ADMFLAG_SLAY) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
         if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+        -- currently argc > 3 for disable helmet feature
+        if argc > 3 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
 
         local targetid = GetPlayerId(args[1])
         if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
@@ -810,12 +840,42 @@ commands:Register("hp", function(playerid, args, argc, silent)
 
         if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
 
-        local health = tonumber(args[2])
-        if health < 0 or health > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+        if argc == 2 then
+            local health = tonumber(args[2])
+            if health < 0 or health > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+            target:health():Set(health)
+            print(string.format(FetchTranslation("admins.hp.message1"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message1"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health))
+        elseif argc == 3 then
+            local health = tonumber(args[2])
+            if health < 0 or health > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+            target:health():Set(health)
 
-        target:health():Set(health)
-        print(string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health))
-        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health))
+            local armor = tonumber(args[3])
+            if armor < 0 or armor > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.invalid_armor"), config:Fetch("admins.prefix"), 0, 999)) end
+            target:armor():Set(armor)
+
+            print(string.format(FetchTranslation("admins.hp.message2"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health, armor))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message2"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health, armor))
+        elseif argc == 4 then
+            local health = tonumber(args[2])
+            if health < 0 or health > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.invalid_health"), config:Fetch("admins.prefix"), 0, 999)) end
+            target:health():Set(health)
+
+            local armor = tonumber(args[3])
+            if armor < 0 or armor > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.invalid_armor"), config:Fetch("admins.prefix"), 0, 999)) end
+
+            local helmet = tonumber(args[4])
+            if helmet < 0 or helmet > 1 then return print(string.format(FetchTranslation("admins.hp.invalid_helmet"), config:Fetch("admins.prefix"), 0, 1)) end
+
+            if helmet == 1 then target:weapons():GiveWeapons("item_assaultsuit") 
+            elseif helmet == 0 then
+                -- TODO: Remove helmet feature
+            end
+            target:armor():Set(armor)
+            print(string.format(FetchTranslation("admins.hp.message3"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health, armor, helmet))
+            playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.hp.message3"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), health, armor, helmet))
+        end
     end
 end)
 
@@ -1209,5 +1269,45 @@ commands:Register("god", function(playerid, args, argc, silent)
             print(string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.enabled")))
             playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.god.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), FetchTranslation("admins.enabled")))
         end
+    end
+end)
+
+commands:Register("armor", function(playerid, args, argc, silent)
+    if playerid == -1 then
+        if argc < 2 then return print(string.format(FetchTranslation("admins.armor.syntax"), config:Fetch("admins.prefix"), "sw_")) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return print(string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return print(string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        local armor = tonumber(args[2])
+        if armor < 0 or armor > 999 then return print(string.format(FetchTranslation("admins.armor.invalid_armor"), config:Fetch("admins.prefix"), 0, 999)) end
+
+        target:armor():Set(armor)
+        print(string.format(FetchTranslation("admins.armor.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), armor))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.armor.message"), config:Fetch("admins.prefix"), "CONSOLE", target:GetName(), armor))
+    else
+        local player = GetPlayer(playerid)
+        if not player then return end
+
+        if not PlayerHasFlag(player, ADMFLAG_KICK) then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.no_access"), config:Fetch("admins.prefix"))) end
+        if argc < 2 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.armor.syntax"), config:Fetch("admins.prefix"), GetPrefix(silent))) end
+
+        local targetid = GetPlayerId(args[1])
+        if targetid == -1 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.invalid_player"), config:Fetch("admins.prefix"))) end
+
+        local target = GetPlayer(targetid)
+        if not target then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.player_not_connected"), config:Fetch("admins.prefix"), args[1])) end
+
+        if target:vars():Get("admin.immunity") > player:vars():Get("admin.immunity") then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.cannot_use_command"), config:Fetch("admins.prefix"))) end
+
+        local armor = tonumber(args[2])
+        if armor < 0 or armor > 999 then return player:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.armor.invalid_armor"), config:Fetch("admins.prefix"), 0, 999)) end
+
+        target:armor():Set(armor)
+        print(string.format(FetchTranslation("admins.armor.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), armor))
+        playermanager:SendMsg(MessageType.Chat, string.format(FetchTranslation("admins.armor.message"), config:Fetch("admins.prefix"), player:GetName(), target:GetName(), armor))
     end
 end)

--- a/src/modules/GameEvents.lua
+++ b/src/modules/GameEvents.lua
@@ -52,11 +52,12 @@ end)
 
 events:on("OnPlayerDamage", function(playerid, damage, damagetype, bullettype, damageflags)
     local player = GetPlayer(playerid)
-    if not player then return end
+    if not player then return true end
 
     if player:vars():Get("godmode") == 1 then
         return false
     end
+    return true
 end)
 
 events:on("OnPlayerSpawn", function(playerid)

--- a/src/modules/GameEvents.lua
+++ b/src/modules/GameEvents.lua
@@ -68,10 +68,10 @@ events:on("OnPlayerSpawn", function(playerid)
     end
 end)
 
---storage each deathposition on event OnPlayerDeath for each player
-events:on("OnPlayerDeath", function(playerid, killerid, reason)
+events:on("OnPlayerDeath", function(playerid)
     local player = GetPlayer(playerid)
     if not player then return end
 
-    player:vars():Set("deathposition", player:coords():Get())
+    local position = player:coords():Get()
+    player:vars():Set("deathposition", tostring(position))
 end)

--- a/src/modules/GameEvents.lua
+++ b/src/modules/GameEvents.lua
@@ -49,3 +49,21 @@ events:on("ShouldHearVoice", function(playerid)
     
     return (player:vars():Get("sanctions.ismuted") == 0)
 end)
+
+events:on("OnPlayerDamage", function(playerid, damage, damagetype, bullettype, damageflags)
+    local player = GetPlayer(playerid)
+    if not player then return end
+
+    if player:vars():Get("godmode") == 1 then
+        return false
+    end
+end)
+
+events:on("OnPlayerSpawn", function(playerid)
+    local player = GetPlayer(playerid)
+    if not player then return end
+
+    if player:vars():Get("godmode") == 1 then
+        player:vars():Set("godmode", 0)
+    end
+end)

--- a/src/modules/GameEvents.lua
+++ b/src/modules/GameEvents.lua
@@ -67,3 +67,11 @@ events:on("OnPlayerSpawn", function(playerid)
         player:vars():Set("godmode", 0)
     end
 end)
+
+--storage each deathposition on event OnPlayerDeath for each player
+events:on("OnPlayerDeath", function(playerid, killerid, reason)
+    local player = GetPlayer(playerid)
+    if not player then return end
+
+    player:vars():Set("deathposition", player:coords():Get())
+end)

--- a/src/modules/GameEvents.lua
+++ b/src/modules/GameEvents.lua
@@ -66,6 +66,14 @@ events:on("OnPlayerSpawn", function(playerid)
     if player:vars():Get("godmode") == 1 then
         player:vars():Set("godmode", 0)
     end
+
+    if player:vars():Get("noclip") == 1 then
+        player:vars():Set("noclip", 0)
+    end
+
+    if player:vars():Get("freeze") == 1 then
+        player:vars():Set("freeze", 0)
+    end
 end)
 
 events:on("OnPlayerDeath", function(playerid)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -57,3 +57,16 @@ function IsValidWeapon(weapon)
 
 	return false
 end
+
+function IsValidItem(item)
+	local itemList = {
+		"item_assaultsuit",
+		"item_kevlar" -- just this two are working in CS2 at the moment.
+	}
+
+	for _, v in ipairs(itemList) do
+		if item == v then return true end
+	end
+
+	return false
+end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1,9 +1,9 @@
 function HasFlag(flags, flag)
-   	return ((flags & flag) == flag) 
+		return ((flags & flag) == flag) 
 end
 
 function PlayerHasFlag(player, flag)
-   	 return HasFlag(player:vars():Get("admin.flags"), flag)
+		return HasFlag(player:vars():Get("admin.flags"), flag)
 end
 
 function IsValidWeapon(weapon)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -70,3 +70,19 @@ function IsValidItem(item)
 
 	return false
 end
+
+-- Vector3
+string.split = function(string, split)
+	local splitted = {}
+	for split in string.gmatch(string, "[^"..split.."]+") do 
+			table.insert(splitted, split) 
+	end
+	return splitted
+end
+
+function toVector3(str)
+	local positions = string.split(string.gsub(str, "vector3", ""), ",")
+	for i=1,#positions do positions[i] = tonumber(string.match(positions[i], "%-%d*%.?%d+") or string.match(positions[i], "%d*%.?%d+")) end
+	return vector3(table.unpack(positions))
+end
+--

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -5,3 +5,55 @@ end
 function PlayerHasFlag(player, flag)
    	 return HasFlag(player:vars():Get("admin.flags"), flag)
 end
+
+function IsValidWeapon(weapon)
+	local weaponlist = {
+			"weapon_ak47",
+			"weapon_aug",
+			"weapon_awp",
+			"weapon_bizon",
+			"weapon_cz75a",
+			"weapon_deagle",
+			"weapon_elite",
+			"weapon_famas",
+			"weapon_fiveseven",
+			"weapon_g3sg1",
+			"weapon_galilar",
+			"weapon_glock",
+			"weapon_m249",
+			"weapon_m4a1",
+			"weapon_mac10",
+			"weapon_mag7",
+			"weapon_mp5sd",
+			"weapon_mp7",
+			"weapon_mp9",
+			"weapon_negev",
+			"weapon_nova",
+			"weapon_p2000",
+			"weapon_p250",
+			"weapon_p90",
+			"weapon_sawedoff",
+			"weapon_scar20",
+			"weapon_sg556",
+			"weapon_ssg08",
+			"weapon_tec9",
+			"weapon_ump45",
+			"weapon_usp_silencer",
+			"weapon_xm1014",
+			"weapon_knife",
+			"weapon_flashbang",
+			"weapon_hegrenade",
+			"weapon_smokegrenade",
+			"weapon_molotov",
+			"weapon_decoy",
+			"weapon_incgrenade",
+			"weapon_c4",
+			"weapon_healthshot"
+	}
+
+	for _, v in ipairs(weaponlist) do
+			if weapon == v then return true end
+	end
+
+	return false
+end


### PR DESCRIPTION
>[!NOTE]
> Check `ro` phrases 'cos were generated by IA.
> [Click here](https://github.com/swiftly-solution/swiftly_admins/blob/d995297c761723b30f66e404e602dcdbe98648b5/plugin_files/translations/translation.admins.json) to check translations file.

I've left the `!god` command commented out because it hooks into a temporarily disabled event.